### PR TITLE
Add sessionAffinity support to Helm service template

### DIFF
--- a/helm/altinity-mcp/README.md
+++ b/helm/altinity-mcp/README.md
@@ -74,6 +74,8 @@ A Helm chart for Altinity MCP Server
 | securityContext | object | `{}` | Container security context |
 | service.annotations | object | `{}` | Service annotations |
 | service.port | int | `8080` | Service port |
+| service.sessionAffinity | string | `nil` | Session affinity type. Set to "ClientIP" to enable sticky sessions. |
+| service.sessionAffinityConfig | object | `nil` | Session affinity configuration (only used when sessionAffinity is set) |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/helm/altinity-mcp/templates/service.yaml
+++ b/helm/altinity-mcp/templates/service.yaml
@@ -10,6 +10,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.sessionAffinity }}
+  sessionAffinity: {{ . }}
+  {{- end }}
+  {{- with .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/helm/altinity-mcp/values.yaml
+++ b/helm/altinity-mcp/values.yaml
@@ -52,6 +52,12 @@ service:
   port: 8080
   # -- Service annotations
   annotations: {}
+  # -- Session affinity type. Set to "ClientIP" to enable sticky sessions.
+  # sessionAffinity: ClientIP
+  # -- Session affinity configuration (only used when sessionAffinity is set)
+  # sessionAffinityConfig:
+  #   clientIP:
+  #     timeoutSeconds: 10800
 
 ingress:
   # -- Enable ingress controller resource


### PR DESCRIPTION
Allow configuring service.sessionAffinity and
service.sessionAffinityConfig in values.yaml so users can enable sticky sessions (e.g. ClientIP with custom timeout).