### PR TITLE
helm: make liveness/readiness probe paths configurable

### DIFF
--- a/helm/altinity-mcp/README.md
+++ b/helm/altinity-mcp/README.md
@@ -69,6 +69,13 @@ A Helm chart for Altinity MCP Server
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Pod annotations |
 | podSecurityContext | object | `{}` | Pod security context |
+| probes | object | `{"liveness":{"initialDelaySeconds":7,"path":"/livez","periodSeconds":30},"readiness":{"initialDelaySeconds":7,"path":"/health","periodSeconds":30}}` | Probe configuration |
+| probes.liveness.initialDelaySeconds | int | `7` | Initial delay before liveness probe starts |
+| probes.liveness.path | string | `"/livez"` | Path for the liveness probe |
+| probes.liveness.periodSeconds | int | `30` | How often to perform the liveness probe |
+| probes.readiness.initialDelaySeconds | int | `7` | Initial delay before readiness probe starts |
+| probes.readiness.path | string | `"/health"` | Path for the readiness probe |
+| probes.readiness.periodSeconds | int | `30` | How often to perform the readiness probe |
 | replicaCount | int | `1` | Number of replicas to deploy |
 | resources | object | `{}` | Container resource requests and limits |
 | securityContext | object | `{}` | Container security context |

--- a/helm/altinity-mcp/templates/deployment.yaml
+++ b/helm/altinity-mcp/templates/deployment.yaml
@@ -48,16 +48,16 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /livez
+              path: {{ .Values.probes.liveness.path }}
               port: http
-            initialDelaySeconds: 7
-            periodSeconds: 30
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.probes.readiness.path }}
               port: http
-            initialDelaySeconds: 7
-            periodSeconds: 30
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/altinity-mcp/values.yaml
+++ b/helm/altinity-mcp/values.yaml
@@ -82,6 +82,23 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- Probe configuration
+probes:
+  liveness:
+    # -- Path for the liveness probe
+    path: /livez
+    # -- Initial delay before liveness probe starts
+    initialDelaySeconds: 7
+    # -- How often to perform the liveness probe
+    periodSeconds: 30
+  readiness:
+    # -- Path for the readiness probe
+    path: /health
+    # -- Initial delay before readiness probe starts
+    initialDelaySeconds: 7
+    # -- How often to perform the readiness probe
+    periodSeconds: 30
+
 # -- Container resource requests and limits
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Summary

- Makes the liveness and readiness probe HTTP paths configurable via Helm values (`probes.liveness.path` / `probes.readiness.path`)
- Also exposes `initialDelaySeconds` and `periodSeconds` as configurable values for both probes

