### PR TITLE
feat(helm): add configurable selectorLabels

### DIFF
--- a/helm/altinity-mcp/README.md
+++ b/helm/altinity-mcp/README.md
@@ -79,6 +79,7 @@ A Helm chart for Altinity MCP Server
 | replicaCount | int | `1` | Number of replicas to deploy |
 | resources | object | `{}` | Container resource requests and limits |
 | securityContext | object | `{}` | Container security context |
+| selectorLabels | object | `{}` | Additional selector labels to add to deployment matchLabels and service selector. **WARNING:** Changing these after initial install requires recreating the Deployment because `spec.selector.matchLabels` is immutable. |
 | service.annotations | object | `{}` | Service annotations |
 | service.port | int | `8080` | Service port |
 | service.sessionAffinity | string | `nil` | Session affinity type. Set to "ClientIP" to enable sticky sessions. |

--- a/helm/altinity-mcp/templates/_helpers.tpl
+++ b/helm/altinity-mcp/templates/_helpers.tpl
@@ -48,6 +48,9 @@ Selector labels
 {{- define "altinity-mcp.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "altinity-mcp.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.selectorLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/altinity-mcp/values.yaml
+++ b/helm/altinity-mcp/values.yaml
@@ -29,6 +29,13 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- Additional selector labels to add to deployment matchLabels and service selector.
+# WARNING: Changing these after initial install requires recreating the Deployment
+# because spec.selector.matchLabels is immutable.
+selectorLabels: {}
+#   app: my-app
+#   component: mcp
+
 # -- Pod annotations
 podAnnotations: {}
 


### PR DESCRIPTION
Allow users to specify additional selector labels via values.selectorLabels that are merged into deployment matchLabels, pod template labels, and service selector.