### PR TITLE
oauth: H-1 — refuse to start when gating + cluster_secret without require_email_verified

### DIFF
--- a/cmd/altinity-mcp/main.go
+++ b/cmd/altinity-mcp/main.go
@@ -1093,6 +1093,21 @@ func validateOAuthRuntimeConfig(cfg config.Config) error {
 		return fmt.Errorf("oauth forward mode requires clickhouse protocol http")
 	}
 
+	// H-1: gating + cluster_secret uses oauthClaims.Email verbatim as the
+	// ClickHouse `initial_user`; ClickHouse trusts the impersonation because
+	// the cluster_secret authenticates the peer. Without RequireEmailVerified,
+	// any IdP-issued token with email_verified=false (e.g. an Auth0 Database
+	// Connection that forgot to require verification, a self-hosted OIDC, a
+	// federated partner IdP) lets the bearer impersonate any provisioned CH
+	// user just by typing their email at registration. Refuse to start unless
+	// the operator explicitly opts in to the verified-email check.
+	if cfg.Server.OAuth.IsGatingMode() &&
+		strings.TrimSpace(cfg.ClickHouse.ClusterSecret) != "" &&
+		!cfg.Server.OAuth.RequireEmailVerified {
+		return fmt.Errorf("oauth gating mode + clickhouse cluster_secret requires oauth.require_email_verified=true (set MCP_OAUTH_REQUIRE_EMAIL_VERIFIED=true): " +
+			"without it, any IdP-issued token with email_verified=false can impersonate the named CH user via initial_user")
+	}
+
 	return nil
 }
 

--- a/cmd/altinity-mcp/main_test.go
+++ b/cmd/altinity-mcp/main_test.go
@@ -3307,6 +3307,87 @@ func TestValidateOAuthRuntimeConfig(t *testing.T) {
 		}
 		require.NoError(t, validateOAuthRuntimeConfig(cfg))
 	})
+
+	// H-1: gating + cluster_secret + !RequireEmailVerified = unverified-email
+	// impersonation risk. Refuse to start.
+	t.Run("gating_with_cluster_secret_requires_email_verified", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.Config{
+			Server: config.ServerConfig{OAuth: config.OAuthConfig{
+				Enabled:              true,
+				Mode:                 "gating",
+				SigningSecret:        "test-signing-secret-32-byte-key!!",
+				RequireEmailVerified: false,
+			}},
+			ClickHouse: config.ClickHouseConfig{
+				Protocol:      config.TCPProtocol,
+				ClusterName:   "demo",
+				ClusterSecret: "shared-cluster-interserver-secret",
+			},
+		}
+		err := validateOAuthRuntimeConfig(cfg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "require_email_verified=true")
+	})
+
+	t.Run("gating_with_cluster_secret_and_email_verified_passes", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.Config{
+			Server: config.ServerConfig{OAuth: config.OAuthConfig{
+				Enabled:              true,
+				Mode:                 "gating",
+				SigningSecret:        "test-signing-secret-32-byte-key!!",
+				RequireEmailVerified: true,
+			}},
+			ClickHouse: config.ClickHouseConfig{
+				Protocol:      config.TCPProtocol,
+				ClusterName:   "demo",
+				ClusterSecret: "shared-cluster-interserver-secret",
+			},
+		}
+		require.NoError(t, validateOAuthRuntimeConfig(cfg))
+	})
+
+	t.Run("gating_without_cluster_secret_doesnt_require_email_verified", func(t *testing.T) {
+		t.Parallel()
+		// Static-creds gating mode: the email claim never reaches CH as
+		// initial_user, so RequireEmailVerified isn't load-bearing here.
+		cfg := config.Config{
+			Server: config.ServerConfig{OAuth: config.OAuthConfig{
+				Enabled:              true,
+				Mode:                 "gating",
+				SigningSecret:        "test-signing-secret-32-byte-key!!",
+				RequireEmailVerified: false,
+			}},
+			ClickHouse: config.ClickHouseConfig{Protocol: config.TCPProtocol},
+		}
+		require.NoError(t, validateOAuthRuntimeConfig(cfg))
+	})
+
+	t.Run("forward_with_cluster_secret_doesnt_trigger_check", func(t *testing.T) {
+		t.Parallel()
+		// Forward mode never uses oauthClaims.Email as initial_user — CH
+		// re-validates the bearer itself. The H-1 check is gating-specific.
+		// (Note: forward+cluster_secret is also rejected for being
+		// http-only-vs-tcp incompatible elsewhere; we just want to confirm
+		// the H-1 check doesn't fire.)
+		cfg := config.Config{
+			Server: config.ServerConfig{OAuth: config.OAuthConfig{
+				Enabled:              true,
+				Mode:                 "forward",
+				SigningSecret:        "test-signing-secret-32-byte-key!!",
+				RequireEmailVerified: false,
+			}},
+			ClickHouse: config.ClickHouseConfig{
+				Protocol:      config.HTTPProtocol,
+				ClusterName:   "demo",
+				ClusterSecret: "shared-cluster-interserver-secret",
+			},
+		}
+		// Should pass H-1 (forward mode); other checks may fail elsewhere
+		// but validateOAuthRuntimeConfig itself should not fail on H-1.
+		require.NoError(t, validateOAuthRuntimeConfig(cfg))
+	})
 }
 
 func TestValidateClusterSecretConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

H-1 from the OAuth security review: **refuse to start in gating mode when `clickhouse.cluster_secret` is set but `oauth.require_email_verified` is false**.

This is the second of a 3-PR stack:

1. PR #104 — spec-compliance hardening + HKDF + C-1 (base of this PR)
2. **This PR (PR-B)** — H-1 require_email_verified gate
3. PR-C (after this lands) — H-2 refresh-token reuse detection ([#103](https://github.com/Altinity/altinity-mcp/issues/103))

> **Note on PR base:** This PR is stacked on top of #104. Until #104 merges, the diff shown is against `feature/oauth-spec-compliance-hardening`. Once #104 lands, GitHub will auto-rebase this onto `main` and the diff will narrow to the H-1 commit alone.

## Threat model

In **gating mode** with `clickhouse.cluster_secret` configured, the path at `pkg/server/server_client.go:303-311` feeds `oauthClaims.Email` *verbatim* into ClickHouse's `initial_user`. ClickHouse trusts the impersonation because the cluster_secret authenticates the **peer**, not the end user.

Without `oauth.require_email_verified=true`, any IdP-issued token with `email_verified=false` lets the bearer impersonate **any** ClickHouse user just by typing their email at registration:

- Auth0 Database Connection that forgot to require verification
- Self-hosted OIDC without verification gating
- Federated partner IdP with weak verification

Auth0's hosted social-login providers (Google, GitHub) emit `email_verified=true` reliably, but a misconfigured custom DB connection or a permissive partner IdP can issue `email_verified=false` tokens.

## Mitigation

`validateOAuthRuntimeConfig` in `cmd/altinity-mcp/main.go` refuses to boot when `IsGatingMode() && cluster_secret != "" && !RequireEmailVerified`. Operators must explicitly opt in to the verified-email check, and the binary won't start without it. Auth0 + Google Social emit `email_verified=true` on every token, so this is safe to enable in our demo deployments.

The `RequireEmailVerified` field already existed in `OAuthConfig` (used by `validateOAuthIdentityPolicy`); this PR only adds the *startup* check that makes it mandatory under the dangerous combination.

## Live deployment

Already running on `otel-mcp.demo.altinity.cloud` since the H-1 deploy (image `feature-strict-schema-14da408`). `currentUser()` returns `btyshkevich@altinity.com` confirming the gating-mode + cluster_secret + email-verified chain works correctly with verified Auth0 + Google Social tokens.

## Test plan

- [x] New test in `cmd/altinity-mcp/oauth_server_test.go` exercises `validateOAuthRuntimeConfig` rejection with the dangerous combination
- [x] Live on otel-mcp; smoke test through claude.ai connector returns the impersonated email
- [ ] CI green on the stacked diff
- [ ] Reviewer eyes on the startup-error message wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)
