### PR TITLE
oauth: H-2 — refresh-token reuse detection (gating mode)

### DIFF
--- a/cmd/altinity-mcp/main.go
+++ b/cmd/altinity-mcp/main.go
@@ -881,6 +881,13 @@ func warnOAuthMisconfiguration(cfg config.Config) {
 			"the MCP server will forward them as-is and rely entirely on ClickHouse-side validation. " +
 			"Set MCP_OAUTH_ISSUER or MCP_OAUTH_JWKS_URL to enable local validation per MCP authorization spec §Token Handling.")
 	}
+	if oauth.RefreshRevokesTracking {
+		log.Info().
+			Str("consumed_jtis_table", "altinity.oauth_refresh_consumed_jtis").
+			Str("revoked_families_table", "altinity.oauth_refresh_revoked_families").
+			Str("expected_pool_user", strings.TrimSpace(cfg.ClickHouse.Username)).
+			Msg("OAuth refresh-token reuse detection (H-2) is enabled — operator must have run docs/sql/oauth-state.sql and granted INSERT,SELECT on altinity.* to the pool user")
+	}
 }
 
 // testConnection tests the connection to ClickHouse
@@ -1106,6 +1113,23 @@ func validateOAuthRuntimeConfig(cfg config.Config) error {
 		!cfg.Server.OAuth.RequireEmailVerified {
 		return fmt.Errorf("oauth gating mode + clickhouse cluster_secret requires oauth.require_email_verified=true (set MCP_OAUTH_REQUIRE_EMAIL_VERIFIED=true): " +
 			"without it, any IdP-issued token with email_verified=false can impersonate the named CH user via initial_user")
+	}
+
+	// H-2: refresh-token reuse detection requires gating mode (forward mode
+	// is unsupported — Auth0 already rotates upstream refresh tokens) and a
+	// writable mcp_service connection. CH-side READONLY=1 profile must also
+	// be cleared, but that's the operator's responsibility — we can't
+	// inspect profile from this side without a CH round-trip.
+	if cfg.Server.OAuth.RefreshRevokesTracking {
+		if !cfg.Server.OAuth.IsGatingMode() {
+			return fmt.Errorf("oauth refresh_revokes_tracking is only supported in gating mode; forward mode delegates rotation+reuse-detection to the upstream IdP")
+		}
+		if cfg.ClickHouse.ReadOnly {
+			return fmt.Errorf("oauth refresh_revokes_tracking requires clickhouse.read_only=false (the H-2 reuse-detection store needs INSERT on altinity.oauth_refresh_consumed_jtis and altinity.oauth_refresh_revoked_families)")
+		}
+		if strings.TrimSpace(cfg.ClickHouse.Database) == "" {
+			return fmt.Errorf("oauth refresh_revokes_tracking requires a non-empty clickhouse.database (the connection's default database; the H-2 state tables themselves live in the literal `altinity` database, hardcoded in queries)")
+		}
 	}
 
 	return nil

--- a/cmd/altinity-mcp/oauth_server.go
+++ b/cmd/altinity-mcp/oauth_server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/altinity/altinity-mcp/pkg/config"
 	"github.com/altinity/altinity-mcp/pkg/jwe_auth"
+	"github.com/altinity/altinity-mcp/pkg/oauth_state"
 	altinitymcp "github.com/altinity/altinity-mcp/pkg/server"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/rs/zerolog/log"
@@ -650,6 +651,18 @@ func randomToken(prefix string) string {
 		panic(err)
 	}
 	return prefix + base64.RawURLEncoding.EncodeToString(buf)
+}
+
+// generateOAuthRandomID returns a 16-byte (128-bit) random hex-encoded
+// identifier suitable for refresh-token jti and family_id claims (H-2).
+// 32 hex characters; collision probability is negligible at our token
+// volume but verifiable via the consumed-jtis store regardless.
+func generateOAuthRandomID() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
 }
 
 func encodeSelfIssuedAccessToken(secret []byte, claims map[string]interface{}) (string, error) {
@@ -1378,6 +1391,15 @@ type gatingIdentity struct {
 	// as the `aud` claim — preserving trailing-slash form for byte-equality
 	// with what the client sent.
 	Resource string
+	// FamilyID is the OAuth refresh-token family identifier (H-2 reuse
+	// detection). At initial code→token exchange this is empty and
+	// mintGatingTokenResponse generates a fresh one. On refresh, the caller
+	// extracts the family_id from the old refresh JWE and passes it through
+	// so the new pair stays in the same family.
+	//
+	// Always non-empty in the minted refresh token's claims when
+	// oauth.refresh_revokes_tracking is enabled. Ignored otherwise.
+	FamilyID string
 }
 
 // mintGatingTokenResponse mints an access token and a stateless refresh token
@@ -1428,7 +1450,7 @@ func (a *application) mintGatingTokenResponse(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	refreshToken, err := encodeOAuthJWE(secret, hkdfInfoOAuthRefresh, map[string]interface{}{
+	refreshClaims := map[string]interface{}{
 		"sub":            id.Subject,
 		"iss":            issuer,
 		"aud":            audience,
@@ -1440,7 +1462,36 @@ func (a *application) mintGatingTokenResponse(w http.ResponseWriter, r *http.Req
 		"hd":             id.HostedDomain,
 		"email_verified": id.EmailVerified,
 		"client_id":      id.ClientID,
-	})
+	}
+
+	// H-2: when refresh-token reuse detection is enabled, every issued
+	// refresh token carries a fresh jti and a stable family_id. The family
+	// is established at initial code→token exchange (FamilyID empty →
+	// generate) and propagated through every rotation (FamilyID supplied
+	// from the previous refresh's claims). When the flag is off we leave
+	// the claims unset so existing forward-mode and pre-H-2 deployments
+	// keep producing identical token shapes.
+	if cfg.Server.OAuth.RefreshRevokesTracking {
+		jti, gerr := generateOAuthRandomID()
+		if gerr != nil {
+			log.Error().Err(gerr).Msg("Failed to generate refresh-token jti")
+			writeOAuthTokenError(w, http.StatusInternalServerError, "server_error", gerr.Error())
+			return
+		}
+		family := id.FamilyID
+		if family == "" {
+			family, gerr = generateOAuthRandomID()
+			if gerr != nil {
+				log.Error().Err(gerr).Msg("Failed to generate refresh-token family_id")
+				writeOAuthTokenError(w, http.StatusInternalServerError, "server_error", gerr.Error())
+				return
+			}
+		}
+		refreshClaims["jti"] = jti
+		refreshClaims["family_id"] = family
+	}
+
+	refreshToken, err := encodeOAuthJWE(secret, hkdfInfoOAuthRefresh, refreshClaims)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to mint refresh token")
 		writeOAuthTokenError(w, http.StatusInternalServerError, "server_error", err.Error())
@@ -1737,6 +1788,54 @@ func (a *application) handleOAuthTokenRefresh(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// H-2: refresh-token reuse detection. When enabled, the refresh JWE must
+	// carry both jti and family_id (added by mintGatingTokenResponse). We
+	// look up jti against the consumed-set and family_id against the revoked
+	// -set; on a hit we record the family as revoked and reject the request.
+	// On a miss we mark the jti consumed and propagate the family_id into
+	// the new token pair so the chain stays linkable.
+	//
+	// Pre-H-2 refresh tokens lack these claims and are rejected with
+	// invalid_grant — clients re-authenticate once. This is the documented
+	// rollout cost; "auto-promote on first use" was rejected because it
+	// would let a captured pre-deploy token be replayed exactly once before
+	// the server starts tracking.
+	familyID := ""
+	if store := a.mcpServer.RefreshStateStore(); store != nil {
+		jti, _ := claims["jti"].(string)
+		family, _ := claims["family_id"].(string)
+		if jti == "" || family == "" {
+			log.Error().
+				Str("client_id", clientID).
+				Str("sub", sub).
+				Bool("has_jti", jti != "").
+				Bool("has_family_id", family != "").
+				Msg("OAuth refresh token rejected: missing jti or family_id (legacy or malformed)")
+			writeOAuthTokenError(w, http.StatusBadRequest, "invalid_grant", "refresh token format unsupported, please re-authenticate")
+			return
+		}
+
+		switch err := store.CheckAndConsume(r.Context(), jti, family, "reuse_detected"); {
+		case errors.Is(err, oauth_state.ErrRefreshReused):
+			log.Error().
+				Str("family_id", family).
+				Str("client_id", clientID).
+				Str("sub", sub).
+				Msg("OAuth refresh token reuse detected — family revoked")
+			writeOAuthTokenError(w, http.StatusBadRequest, "invalid_grant", "refresh token reuse detected, please re-authenticate")
+			return
+		case err != nil:
+			log.Error().
+				Err(err).
+				Str("family_id", family).
+				Str("client_id", clientID).
+				Msg("OAuth refresh state lookup failed — hard fail")
+			writeOAuthTokenError(w, http.StatusInternalServerError, "server_error", "refresh state unavailable")
+			return
+		}
+		familyID = family
+	}
+
 	a.mintGatingTokenResponse(w, r, secret, gatingIdentity{
 		ClientID:      clientID,
 		Subject:       sub,
@@ -1746,6 +1845,7 @@ func (a *application) handleOAuthTokenRefresh(w http.ResponseWriter, r *http.Req
 		EmailVerified: emailVerified,
 		Scope:         scope,
 		Resource:      resource,
+		FamilyID:      familyID,
 	})
 }
 

--- a/cmd/altinity-mcp/oauth_server_test.go
+++ b/cmd/altinity-mcp/oauth_server_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +19,7 @@ import (
 
 	"github.com/altinity/altinity-mcp/pkg/config"
 	"github.com/altinity/altinity-mcp/pkg/jwe_auth"
+	"github.com/altinity/altinity-mcp/pkg/oauth_state"
 	altinitymcp "github.com/altinity/altinity-mcp/pkg/server"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/require"
@@ -2806,6 +2809,409 @@ func TestWriteOAuthTokenError(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	require.Equal(t, "invalid_request", body["error"])
 	require.Equal(t, "bad thing happened", body["error_description"])
+}
+
+// ----------------------------------------------------------------------
+// H-2: refresh-token reuse detection (gating mode)
+// ----------------------------------------------------------------------
+
+// fakeRefreshStateStore is an in-memory oauth_state.Store for testing the
+// refresh-handler control flow without standing up a CH harness. The real
+// SQL is exercised by the live otel deployment's negative-replay test.
+type fakeRefreshStateStore struct {
+	mu        sync.Mutex
+	consumed  map[string]bool   // jti → true
+	revoked   map[string]string // family_id → reason
+	failNext  error             // when set, next call returns this error
+	calls     []fakeStoreCall
+}
+
+type fakeStoreCall struct {
+	JTI      string
+	FamilyID string
+	Reason   string
+}
+
+func newFakeRefreshStateStore() *fakeRefreshStateStore {
+	return &fakeRefreshStateStore{
+		consumed: map[string]bool{},
+		revoked:  map[string]string{},
+	}
+}
+
+func (f *fakeRefreshStateStore) CheckAndConsume(_ context.Context, jti, familyID, reason string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, fakeStoreCall{JTI: jti, FamilyID: familyID, Reason: reason})
+
+	if f.failNext != nil {
+		err := f.failNext
+		f.failNext = nil
+		return err
+	}
+
+	if f.consumed[jti] || f.revoked[familyID] != "" {
+		f.revoked[familyID] = reason
+		return oauth_state.ErrRefreshReused
+	}
+
+	f.consumed[jti] = true
+	return nil
+}
+
+// newGatingModeTestAppWithH2 wires a gating-mode app with H-2 enabled and
+// a fake oauth_state.Store injected. ClickHouse config is not populated —
+// the fake store never touches CH.
+func newGatingModeTestAppWithH2(provider *testForwardModeOIDCProvider) (*application, *fakeRefreshStateStore) {
+	cfg := config.Config{
+		Server: config.ServerConfig{
+			OAuth: config.OAuthConfig{
+				Enabled:                true,
+				Mode:                   "gating",
+				Issuer:                 provider.server.URL,
+				JWKSURL:                provider.server.URL + "/jwks",
+				AuthURL:                provider.server.URL + "/authorize",
+				TokenURL:               provider.server.URL + "/token",
+				UserInfoURL:            provider.server.URL + "/userinfo",
+				ClientID:               "upstream-client-id",
+				ClientSecret:           "upstream-client-secret",
+				Scopes:                 []string{"openid", "email"},
+				SigningSecret:          "test-gating-secret-32-byte-key!!",
+				AccessTokenTTLSeconds:  300,
+				RefreshTokenTTLSeconds: 86400,
+				RefreshRevokesTracking: true,
+			},
+		},
+	}
+	srv := altinitymcp.NewClickHouseMCPServer(cfg, "test")
+	store := newFakeRefreshStateStore()
+	srv.SetRefreshStateStore(store)
+	return &application{
+		config:    cfg,
+		mcpServer: srv,
+	}, store
+}
+
+// inspectRefreshJWE decrypts a refresh-token JWE with the test secret so
+// tests can assert on jti/family_id claims.
+func inspectRefreshJWE(t *testing.T, refreshToken string) map[string]interface{} {
+	t.Helper()
+	secret := []byte("test-gating-secret-32-byte-key!!")
+	claims, err := decodeOAuthJWE(secret, hkdfInfoOAuthRefresh, refreshToken)
+	require.NoError(t, err, "failed to decode test refresh JWE")
+	return claims
+}
+
+func TestOAuthRefreshReuseDetection_HappyPath(t *testing.T) {
+	t.Parallel()
+	const (
+		redirectURI  = "http://127.0.0.1:3334/callback"
+		codeVerifier = "test-code-verifier"
+	)
+
+	provider := newTestForwardModeOIDCProvider(t, map[string]interface{}{
+		"access_token": "upstream-access-token",
+		"token_type":   "Bearer",
+		"expires_in":   1800,
+		"scope":        "openid email",
+	}, nil)
+	provider.tokenResponse["id_token"] = provider.issueIDToken(t, map[string]interface{}{
+		"sub":            "user-1",
+		"iss":            provider.server.URL,
+		"aud":            "upstream-client-id",
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Unix(),
+		"email":          "user@example.com",
+		"email_verified": true,
+	})
+
+	app, store := newGatingModeTestAppWithH2(provider)
+	resp := doGatingAuthCodeFlow(t, app, provider, redirectURI, codeVerifier)
+	clientID := resp["_client_id"].(string)
+
+	// Initial refresh JWE carries jti + family_id.
+	r1 := resp["refresh_token"].(string)
+	r1Claims := inspectRefreshJWE(t, r1)
+	r1Jti, _ := r1Claims["jti"].(string)
+	r1Family, _ := r1Claims["family_id"].(string)
+	require.NotEmpty(t, r1Jti, "refresh token must carry jti when H-2 enabled")
+	require.NotEmpty(t, r1Family, "refresh token must carry family_id when H-2 enabled")
+
+	// Refresh once.
+	rr1 := exchangeRefreshToken(t, app, clientID, r1)
+	require.Equal(t, http.StatusOK, rr1.Code)
+	var resp1 map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr1.Body.Bytes(), &resp1))
+
+	r2 := resp1["refresh_token"].(string)
+	r2Claims := inspectRefreshJWE(t, r2)
+	r2Jti, _ := r2Claims["jti"].(string)
+	r2Family, _ := r2Claims["family_id"].(string)
+
+	require.NotEmpty(t, r2Jti, "rotated refresh token must have a fresh jti")
+	require.NotEqual(t, r1Jti, r2Jti, "jti must rotate on every refresh")
+	require.Equal(t, r1Family, r2Family, "family_id must be stable across the rotation chain")
+
+	// Refresh again — chain should keep the same family.
+	rr2 := exchangeRefreshToken(t, app, clientID, r2)
+	require.Equal(t, http.StatusOK, rr2.Code)
+	var resp2 map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr2.Body.Bytes(), &resp2))
+
+	r3 := resp2["refresh_token"].(string)
+	r3Claims := inspectRefreshJWE(t, r3)
+	require.Equal(t, r1Family, r3Claims["family_id"].(string), "family_id stays stable across N refreshes")
+	require.NotEqual(t, r2Jti, r3Claims["jti"].(string), "jti rotates on every refresh")
+
+	// Two refreshes recorded; nothing revoked.
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Len(t, store.calls, 2, "store should see one CheckAndConsume per refresh (R1+R2 redeemed; R3 not yet redeemed)")
+	require.Empty(t, store.revoked, "no family revoked on a clean rotation chain")
+	require.True(t, store.consumed[r1Jti], "R1's jti must be marked consumed")
+	require.True(t, store.consumed[r2Jti], "R2's jti must be marked consumed")
+}
+
+func TestOAuthRefreshReuseDetection_ReplayRevokesFamily(t *testing.T) {
+	t.Parallel()
+	const (
+		redirectURI  = "http://127.0.0.1:3334/callback"
+		codeVerifier = "test-code-verifier"
+	)
+
+	provider := newTestForwardModeOIDCProvider(t, map[string]interface{}{
+		"access_token": "upstream-access-token",
+		"token_type":   "Bearer",
+		"expires_in":   1800,
+		"scope":        "openid email",
+	}, nil)
+	provider.tokenResponse["id_token"] = provider.issueIDToken(t, map[string]interface{}{
+		"sub":            "user-1",
+		"iss":            provider.server.URL,
+		"aud":            "upstream-client-id",
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Unix(),
+		"email":          "user@example.com",
+		"email_verified": true,
+	})
+
+	app, store := newGatingModeTestAppWithH2(provider)
+	resp := doGatingAuthCodeFlow(t, app, provider, redirectURI, codeVerifier)
+	clientID := resp["_client_id"].(string)
+
+	r1 := resp["refresh_token"].(string)
+	r1Family := inspectRefreshJWE(t, r1)["family_id"].(string)
+
+	// First redemption succeeds.
+	rr1 := exchangeRefreshToken(t, app, clientID, r1)
+	require.Equal(t, http.StatusOK, rr1.Code)
+
+	var resp1 map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr1.Body.Bytes(), &resp1))
+	r2 := resp1["refresh_token"].(string)
+
+	// Replay R1 → 400 invalid_grant, family revoked.
+	rrReplay := exchangeRefreshToken(t, app, clientID, r1)
+	require.Equal(t, http.StatusBadRequest, rrReplay.Code)
+	var replayBody map[string]interface{}
+	require.NoError(t, json.Unmarshal(rrReplay.Body.Bytes(), &replayBody))
+	require.Equal(t, "invalid_grant", replayBody["error"])
+	require.Contains(t, replayBody["error_description"], "reuse")
+
+	store.mu.Lock()
+	require.Equal(t, "reuse_detected", store.revoked[r1Family], "family must be in revoked set after replay")
+	store.mu.Unlock()
+
+	// Subsequent legit redemption of R2 — family is now revoked, so this also fails.
+	rrR2 := exchangeRefreshToken(t, app, clientID, r2)
+	require.Equal(t, http.StatusBadRequest, rrR2.Code)
+	var r2Body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rrR2.Body.Bytes(), &r2Body))
+	require.Equal(t, "invalid_grant", r2Body["error"])
+}
+
+func TestOAuthRefreshReuseDetection_LegacyTokenRejected(t *testing.T) {
+	t.Parallel()
+	const (
+		redirectURI  = "http://127.0.0.1:3334/callback"
+		codeVerifier = "test-code-verifier"
+	)
+
+	provider := newTestForwardModeOIDCProvider(t, map[string]interface{}{
+		"access_token": "upstream-access-token",
+		"token_type":   "Bearer",
+		"expires_in":   1800,
+		"scope":        "openid email",
+	}, nil)
+	provider.tokenResponse["id_token"] = provider.issueIDToken(t, map[string]interface{}{
+		"sub":            "user-1",
+		"iss":            provider.server.URL,
+		"aud":            "upstream-client-id",
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Unix(),
+		"email":          "user@example.com",
+		"email_verified": true,
+	})
+
+	// Build app WITHOUT H-2 first to obtain a legacy-shaped refresh token
+	// (no jti, no family_id), then flip the flag to simulate a deploy that
+	// turns reuse-detection on while a legacy token is in flight.
+	cfg := config.Config{
+		Server: config.ServerConfig{
+			OAuth: config.OAuthConfig{
+				Enabled:                true,
+				Mode:                   "gating",
+				Issuer:                 provider.server.URL,
+				JWKSURL:                provider.server.URL + "/jwks",
+				AuthURL:                provider.server.URL + "/authorize",
+				TokenURL:               provider.server.URL + "/token",
+				UserInfoURL:            provider.server.URL + "/userinfo",
+				ClientID:               "upstream-client-id",
+				ClientSecret:           "upstream-client-secret",
+				Scopes:                 []string{"openid", "email"},
+				SigningSecret:          "test-gating-secret-32-byte-key!!",
+				AccessTokenTTLSeconds:  300,
+				RefreshTokenTTLSeconds: 86400,
+				// RefreshRevokesTracking: false initially
+			},
+		},
+	}
+	app := &application{
+		config:    cfg,
+		mcpServer: altinitymcp.NewClickHouseMCPServer(cfg, "test"),
+	}
+	resp := doGatingAuthCodeFlow(t, app, provider, redirectURI, codeVerifier)
+	clientID := resp["_client_id"].(string)
+	legacyRefresh := resp["refresh_token"].(string)
+
+	// Sanity: legacy token has no jti or family_id claims.
+	legacyClaims := inspectRefreshJWE(t, legacyRefresh)
+	require.Empty(t, legacyClaims["jti"])
+	require.Empty(t, legacyClaims["family_id"])
+
+	// Now flip the flag (simulating helm upgrade) and inject a store.
+	cfg.Server.OAuth.RefreshRevokesTracking = true
+	app.config = cfg
+	srv := altinitymcp.NewClickHouseMCPServer(cfg, "test")
+	store := newFakeRefreshStateStore()
+	srv.SetRefreshStateStore(store)
+	app.mcpServer = srv
+
+	rr := exchangeRefreshToken(t, app, clientID, legacyRefresh)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	require.Equal(t, "invalid_grant", body["error"])
+	require.Contains(t, body["error_description"], "re-authenticate")
+
+	// Importantly, the store was never consulted — legacy rejection happens
+	// before the lookup. Otherwise we'd silently INSERT garbage families.
+	store.mu.Lock()
+	require.Empty(t, store.calls, "legacy refresh must be rejected before any store call")
+	store.mu.Unlock()
+}
+
+func TestOAuthRefreshReuseDetection_StateUnreachable(t *testing.T) {
+	t.Parallel()
+	const (
+		redirectURI  = "http://127.0.0.1:3334/callback"
+		codeVerifier = "test-code-verifier"
+	)
+
+	provider := newTestForwardModeOIDCProvider(t, map[string]interface{}{
+		"access_token": "upstream-access-token",
+		"token_type":   "Bearer",
+		"expires_in":   1800,
+		"scope":        "openid email",
+	}, nil)
+	provider.tokenResponse["id_token"] = provider.issueIDToken(t, map[string]interface{}{
+		"sub":            "user-1",
+		"iss":            provider.server.URL,
+		"aud":            "upstream-client-id",
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Unix(),
+		"email":          "user@example.com",
+		"email_verified": true,
+	})
+
+	app, store := newGatingModeTestAppWithH2(provider)
+	resp := doGatingAuthCodeFlow(t, app, provider, redirectURI, codeVerifier)
+	clientID := resp["_client_id"].(string)
+
+	// Arm the store to fail the next call with a generic CH error (simulates
+	// CH unreachable / RBAC denied / timeout).
+	store.mu.Lock()
+	store.failNext = errors.New("clickhouse: connection refused")
+	store.mu.Unlock()
+
+	rr := exchangeRefreshToken(t, app, clientID, resp["refresh_token"].(string))
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	require.Equal(t, "server_error", body["error"])
+	require.Contains(t, body["error_description"], "refresh state unavailable")
+}
+
+func TestOAuthRefreshReuseDetection_ForwardModeRejectsConfig(t *testing.T) {
+	t.Parallel()
+	cfg := config.Config{
+		Server: config.ServerConfig{
+			OAuth: config.OAuthConfig{
+				Enabled:                true,
+				Mode:                   "forward",
+				SigningSecret:          "test-gating-secret-32-byte-key!!",
+				RefreshRevokesTracking: true,
+			},
+		},
+		ClickHouse: config.ClickHouseConfig{
+			Database: "default",
+			Protocol: config.HTTPProtocol,
+		},
+	}
+	err := validateOAuthRuntimeConfig(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refresh_revokes_tracking is only supported in gating mode")
+}
+
+func TestOAuthRefreshReuseDetection_ReadOnlyRejectsConfig(t *testing.T) {
+	t.Parallel()
+	cfg := config.Config{
+		Server: config.ServerConfig{
+			OAuth: config.OAuthConfig{
+				Enabled:                true,
+				Mode:                   "gating",
+				SigningSecret:          "test-gating-secret-32-byte-key!!",
+				RefreshRevokesTracking: true,
+			},
+		},
+		ClickHouse: config.ClickHouseConfig{
+			Database: "default",
+			ReadOnly: true,
+		},
+	}
+	err := validateOAuthRuntimeConfig(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "clickhouse.read_only=false")
+}
+
+func TestOAuthRefreshReuseDetection_EmptyDatabaseRejectsConfig(t *testing.T) {
+	t.Parallel()
+	cfg := config.Config{
+		Server: config.ServerConfig{
+			OAuth: config.OAuthConfig{
+				Enabled:                true,
+				Mode:                   "gating",
+				SigningSecret:          "test-gating-secret-32-byte-key!!",
+				RefreshRevokesTracking: true,
+			},
+		},
+		ClickHouse: config.ClickHouseConfig{
+			Database: "",
+		},
+	}
+	err := validateOAuthRuntimeConfig(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-empty clickhouse.database")
 }
 
 func TestEncodeSelfIssuedAccessToken(t *testing.T) {

--- a/cmd/altinity-mcp/oauth_server_test.go
+++ b/cmd/altinity-mcp/oauth_server_test.go
@@ -2819,11 +2819,18 @@ func TestWriteOAuthTokenError(t *testing.T) {
 // refresh-handler control flow without standing up a CH harness. The real
 // SQL is exercised by the live otel deployment's negative-replay test.
 type fakeRefreshStateStore struct {
-	mu        sync.Mutex
-	consumed  map[string]bool   // jti → true
-	revoked   map[string]string // family_id → reason
-	failNext  error             // when set, next call returns this error
-	calls     []fakeStoreCall
+	mu sync.Mutex
+	consumed map[string]bool   // jti → true
+	revoked  map[string]string // family_id → reason
+	// failNext: next CheckAndConsume call returns this error verbatim
+	// (simulates pre-claim infrastructure failure: CH unreachable, etc.).
+	failNext error
+	// failRevoke: when true and the next call hits the duplicate-key
+	// reuse-detected branch, the revoke INSERT "fails" — the call must
+	// return a non-Err­RefreshReused error (hard fail) per the
+	// security-critical revoke-must-persist invariant.
+	failRevoke bool
+	calls      []fakeStoreCall
 }
 
 type fakeStoreCall struct {
@@ -2851,6 +2858,15 @@ func (f *fakeRefreshStateStore) CheckAndConsume(_ context.Context, jti, familyID
 	}
 
 	if f.consumed[jti] || f.revoked[familyID] != "" {
+		// Reuse-detected branch. If failRevoke is armed, simulate the
+		// security-critical revoke-INSERT-failed case: the call must
+		// return a non-ErrRefreshReused error so the handler hard-fails
+		// (HTTP 500). This guards the invariant that family revocation
+		// must persist before we tell the caller "revoked".
+		if f.failRevoke {
+			f.failRevoke = false
+			return errors.New("simulated revoke INSERT failure (security-critical)")
+		}
 		f.revoked[familyID] = reason
 		return oauth_state.ErrRefreshReused
 	}
@@ -3158,6 +3174,73 @@ func TestOAuthRefreshReuseDetection_StateUnreachable(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	require.Equal(t, "server_error", body["error"])
 	require.Contains(t, body["error_description"], "refresh state unavailable")
+}
+
+// TestOAuthRefreshReuseDetection_RevokeInsertFailureHardFails locks in the
+// invariant that family revocation MUST persist before the handler returns
+// an "invalid_grant reuse_detected" response. Returning ErrRefreshReused
+// would silently leave the winning fork of a forked family alive on every
+// MCP pod that later reads revoked_families. The fix in
+// pkg/oauth_state/store.go promotes revoke-INSERT failures to hard errors
+// (HTTP 500 server_error). This test pins that behavior so a future
+// refactor doesn't quietly downgrade it back to a WARN log.
+func TestOAuthRefreshReuseDetection_RevokeInsertFailureHardFails(t *testing.T) {
+	t.Parallel()
+	const (
+		redirectURI  = "http://127.0.0.1:3334/callback"
+		codeVerifier = "test-code-verifier"
+	)
+
+	provider := newTestForwardModeOIDCProvider(t, map[string]interface{}{
+		"access_token": "upstream-access-token",
+		"token_type":   "Bearer",
+		"expires_in":   1800,
+		"scope":        "openid email",
+	}, nil)
+	provider.tokenResponse["id_token"] = provider.issueIDToken(t, map[string]interface{}{
+		"sub":            "user-1",
+		"iss":            provider.server.URL,
+		"aud":            "upstream-client-id",
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Unix(),
+		"email":          "user@example.com",
+		"email_verified": true,
+	})
+
+	app, store := newGatingModeTestAppWithH2(provider)
+	resp := doGatingAuthCodeFlow(t, app, provider, redirectURI, codeVerifier)
+	clientID := resp["_client_id"].(string)
+
+	// Redeem R0 once — claims its jti, mints R1.
+	rr1 := exchangeRefreshToken(t, app, clientID, resp["refresh_token"].(string))
+	require.Equal(t, http.StatusOK, rr1.Code)
+
+	// Arm the fake to fail the next revoke. The replay below will hit the
+	// duplicate-detected branch in CheckAndConsume; the fake's failRevoke
+	// kicks in and returns a generic error instead of ErrRefreshReused.
+	store.mu.Lock()
+	store.failRevoke = true
+	store.mu.Unlock()
+
+	// Replay R0 — duplicate detected, but revoke INSERT "fails". Handler
+	// must hard-fail (500 server_error), NOT 400 invalid_grant. Returning
+	// 400 here would be a regression — it would tell the caller "family
+	// revoked" while the row didn't actually persist.
+	rrReplay := exchangeRefreshToken(t, app, clientID, resp["refresh_token"].(string))
+	require.Equal(t, http.StatusInternalServerError, rrReplay.Code,
+		"revoke-INSERT failure must hard-fail with 500 server_error, NOT 400 invalid_grant — "+
+			"otherwise the winning fork of a forked family stays alive across pods")
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rrReplay.Body.Bytes(), &body))
+	require.Equal(t, "server_error", body["error"])
+
+	// Sanity: the family was NOT recorded as revoked (because the simulated
+	// INSERT failed). Operators paging on the ERR log line would investigate
+	// the underlying CH/Keeper failure.
+	store.mu.Lock()
+	require.Empty(t, store.revoked,
+		"failed revoke INSERT must NOT show as revoked in store state")
+	store.mu.Unlock()
 }
 
 func TestOAuthRefreshReuseDetection_ForwardModeRejectsConfig(t *testing.T) {

--- a/cmd/altinity-mcp/oauth_server_test.go
+++ b/cmd/altinity-mcp/oauth_server_test.go
@@ -2859,6 +2859,14 @@ func (f *fakeRefreshStateStore) CheckAndConsume(_ context.Context, jti, familyID
 	return nil
 }
 
+// Cleanup is a no-op for the fake; the real KeeperMap-backed store runs
+// `ALTER TABLE altinity.oauth_refresh_consumed_jtis DELETE WHERE
+// consumed_at < now() - INTERVAL …` to bound storage. Tests that exercise
+// the cleanup loop do so via a separate counter-based runner.
+func (f *fakeRefreshStateStore) Cleanup(_ context.Context, _ time.Duration) error {
+	return nil
+}
+
 // newGatingModeTestAppWithH2 wires a gating-mode app with H-2 enabled and
 // a fake oauth_state.Store injected. ClickHouse config is not populated —
 // the fake store never touches CH.
@@ -3212,6 +3220,113 @@ func TestOAuthRefreshReuseDetection_EmptyDatabaseRejectsConfig(t *testing.T) {
 	err := validateOAuthRuntimeConfig(cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "non-empty clickhouse.database")
+}
+
+// TestOAuthRefreshReuseDetection_AtomicConcurrentClaim hammers the H-2
+// refresh handler with N goroutines all redeeming the SAME refresh JWE in
+// parallel. Verifies the atomicity property promised by KeeperMap strict
+// mode: exactly one redeemer wins, all others see invalid_grant with
+// reuse_detected. The fake store synchronises via sync.Mutex (faithful to
+// the production semantics — Keeper Raft serialises through a single
+// leader); this test exercises the handler's branching, not the wire
+// protocol of CH.
+//
+// This is the regression test for the parallel-replay race that the
+// previous SELECT-then-INSERT design left open and that prompted the
+// switch to KeeperMap. If a future refactor reintroduces a check-then-act
+// pattern, this test catches it.
+func TestOAuthRefreshReuseDetection_AtomicConcurrentClaim(t *testing.T) {
+	t.Parallel()
+	const (
+		redirectURI  = "http://127.0.0.1:3334/callback"
+		codeVerifier = "test-code-verifier"
+		concurrency  = 50
+	)
+
+	provider := newTestForwardModeOIDCProvider(t, map[string]interface{}{
+		"access_token": "upstream-access-token",
+		"token_type":   "Bearer",
+		"expires_in":   1800,
+		"scope":        "openid email",
+	}, nil)
+	provider.tokenResponse["id_token"] = provider.issueIDToken(t, map[string]interface{}{
+		"sub":            "user-1",
+		"iss":            provider.server.URL,
+		"aud":            "upstream-client-id",
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Unix(),
+		"email":          "user@example.com",
+		"email_verified": true,
+	})
+
+	app, store := newGatingModeTestAppWithH2(provider)
+	resp := doGatingAuthCodeFlow(t, app, provider, redirectURI, codeVerifier)
+	clientID := resp["_client_id"].(string)
+	r1 := resp["refresh_token"].(string)
+	r1Family := inspectRefreshJWE(t, r1)["family_id"].(string)
+	r1Jti := inspectRefreshJWE(t, r1)["jti"].(string)
+
+	// Synchronise N goroutines on a barrier so they all release into the
+	// refresh handler at once — maximises the chance of overlapping
+	// CheckAndConsume calls. Buffered channels cap on the receiver side.
+	type result struct {
+		status int
+		body   map[string]interface{}
+	}
+	results := make(chan result, concurrency)
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			rr := exchangeRefreshToken(t, app, clientID, r1)
+			var body map[string]interface{}
+			_ = json.Unmarshal(rr.Body.Bytes(), &body)
+			results <- result{status: rr.Code, body: body}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	successes := 0
+	reuseDetected := 0
+	for r := range results {
+		switch r.status {
+		case http.StatusOK:
+			successes++
+		case http.StatusBadRequest:
+			require.Equal(t, "invalid_grant", r.body["error"], "non-200 must be invalid_grant")
+			require.Contains(t, r.body["error_description"], "reuse",
+				"non-200 must be reuse-detected variant of invalid_grant")
+			reuseDetected++
+		default:
+			t.Fatalf("unexpected status %d body %v", r.status, r.body)
+		}
+	}
+
+	require.Equal(t, 1, successes,
+		"exactly one redeemer must win — the atomicity property of KeeperMap strict mode")
+	require.Equal(t, concurrency-1, reuseDetected,
+		"all other redeemers must be rejected with reuse-detected invalid_grant")
+
+	// Inspect store state. The winning JTI is in consumed_jtis exactly once;
+	// the family is in revoked_families because at least one loser wrote it.
+	store.mu.Lock()
+	require.True(t, store.consumed[r1Jti], "winning jti must be marked consumed")
+	require.NotEmpty(t, store.revoked[r1Family],
+		"family must be marked revoked by at least one losing redeemer")
+	require.Equal(t, "reuse_detected", store.revoked[r1Family])
+	store.mu.Unlock()
+
+	// Even though one redeemer "won" — could be the legitimate owner OR
+	// the attacker — the family is now revoked. Subsequent refresh of the
+	// winner's NEW token (which carries the same family_id) is also
+	// rejected. RFC 9700 §refresh-token rotation: server can't tell which
+	// party is legitimate, so the family dies on detection.
 }
 
 func TestEncodeSelfIssuedAccessToken(t *testing.T) {

--- a/docs/oauth-refresh-reuse-detection.md
+++ b/docs/oauth-refresh-reuse-detection.md
@@ -62,19 +62,22 @@ attacker now presents R1: server sees A already in consumed
                         → user re-auths from scratch
 ```
 
-State lives in two ClickHouse tables in the `altinity` database:
+State lives in two ClickHouse tables in the `altinity` database. **Both
+are KeeperMap** so reads and writes are linearizable through Keeper Raft —
+there is no replication-lag window where a pod talking to one CH replica
+fails to see another pod's recent write.
 
-| Table                                        | Engine                  | Atomicity  | Cleanup                    |
-| -------------------------------------------- | ----------------------- | ---------- | -------------------------- |
-| `altinity.oauth_refresh_consumed_jtis`       | KeeperMap (strict mode) | linearizable | in-process `ALTER TABLE … DELETE` goroutine, hourly, 35-day retention |
-| `altinity.oauth_refresh_revoked_families`    | ReplicatedMergeTree     | (idempotent INSERT) | CH-native TTL, 35-day retention |
+| Table                                        | Engine                  | Strict mode | Cleanup                    |
+| -------------------------------------------- | ----------------------- | ----------- | -------------------------- |
+| `altinity.oauth_refresh_consumed_jtis`       | KeeperMap               | yes (per-INSERT) — duplicate jti throws `KEEPER_EXCEPTION` | in-process `ALTER TABLE … DELETE` goroutine, hourly, 35-day retention |
+| `altinity.oauth_refresh_revoked_families`    | KeeperMap               | no — duplicate family_id idempotently overwrites (parallel revokes are fine) | same goroutine, same retention |
 
 Each refresh = 1 cheap `SELECT count() FROM revoked_families` (point lookup
 by family_id) + 1 atomic `INSERT … SETTINGS keeper_map_strict_mode = 1`
 into consumed_jtis. At realistic load (~hundreds of clients refreshing
 ~once per hour) that's on the order of 0.5 qps cluster-wide. Negligible.
 
-### Why KeeperMap and not just ReplicatedMergeTree
+### Why KeeperMap (for both tables) and not ReplicatedMergeTree
 
 The earlier H-2 design used `SELECT count() WHERE jti = ?` followed by
 `INSERT` into a `ReplicatedMergeTree` consumed-jtis table. That pattern
@@ -84,19 +87,54 @@ the INSERT, and the family forks before any reuse is detected. From
 that point an attacker who steals a single token has their own valid
 branch of the family chain and never needs the original token again.
 
-KeeperMap (with `keeper_map_strict_mode=1`) is the fix. It's a key-value
-table engine backed by ClickHouse Keeper's Raft consensus. Concurrent
-INSERTs of the same primary key are serialised through the Keeper
-leader; exactly one wins, the rest receive `KEEPER_EXCEPTION:
-Transaction failed (Node exists)` (Code 999). The MCP store detects
-this signature and returns `ErrRefreshReused` to the handler, which
-records the family revocation and rejects the request. RFC 9700
-§refresh-token rotation: the server cannot tell which of two concurrent
-redeemers is legitimate, so the family dies on detection.
+KeeperMap with `keeper_map_strict_mode=1` is the fix for the consumed-
+jti claim. It's a key-value table engine backed by ClickHouse Keeper's
+Raft consensus. Concurrent INSERTs of the same primary key are
+serialised through the Keeper leader; exactly one wins, the rest
+receive `KEEPER_EXCEPTION: Transaction failed (Node exists)` (Code 999).
+The MCP store detects this signature and proceeds to record the family
+revocation. RFC 9700 §refresh-token rotation: the server cannot tell
+which of two concurrent redeemers is legitimate, so the family dies on
+detection.
+
+The `revoked_families` table is **also** KeeperMap, for a parallel
+reason. Without linearizable reads on revocation state, the refresh
+path's pre-check `SELECT count() FROM revoked_families WHERE
+family_id = F` could miss a recent revoke on a CH replica that hasn't
+yet seen the loser's INSERT. The winner of a forked family could then
+keep refreshing its branch on different MCP pods/replicas while
+replication catches up — exactly the window the design is supposed to
+close. With both tables on Keeper, every refresh sees the
+authoritative state.
 
 KeeperMap doesn't add a Keeper dependency — `ReplicatedMergeTree` is
 already on Keeper for replication coordination. KeeperMap simply
 exposes the linearizable primitive Keeper already provides.
+
+### Revoke must persist (not best-effort)
+
+When the consumed-jti INSERT fails with the duplicate-key exception,
+the handler attempts to record the family revocation. If THAT INSERT
+also fails (Keeper unavailable, etc.), the handler does NOT fall back
+to a "best-effort" rejection. The previous design logged a WARN and
+returned `ErrRefreshReused` regardless; that left the winner's branch
+of the forked family alive for every subsequent refresh against any
+MCP pod, because no row landed in `revoked_families`. The current
+code promotes a failed revoke INSERT to a **hard error** (HTTP 500
+`server_error`); operators page on the ERR log line, the underlying
+Keeper or grant issue gets fixed, and the next attempt to redeem the
+same R0 hits the same code path and writes the revoke for real.
+
+### Post-claim revocation re-check
+
+The pre-check in step (1) of `CheckAndConsume` and the atomic claim in
+step (2) are not a single Keeper transaction. There's a microsecond
+window between them where another pod could revoke the family. The
+store closes this TOCTOU by re-checking revocation **after** the claim
+succeeds. If revocation arrived during the window, the response is
+`ErrRefreshReused` (HTTP 400 invalid_grant); the consumed-jti slot is
+spent but no token is minted. The family stays revoked, all subsequent
+refreshes fail at step (1), the user re-auths.
 
 ### `keeper_map_strict_mode` is per-query
 
@@ -220,6 +258,8 @@ pair anyway" — that would defeat the security control.
 | Refresh JWE missing `jti` or `family_id` (legacy or malformed) | 400 `invalid_grant` "refresh token format unsupported, please re-authenticate" | ERR `OAuth refresh token rejected: missing jti or family_id` |
 | Family already in `revoked_families` (legitimate owner refreshing post-revocation) | 400 `invalid_grant` "refresh token reuse detected" | ERR `OAuth refresh token reuse detected — family revoked` |
 | Concurrent or sequential jti replay (KeeperMap dup-key) | 400 `invalid_grant` "refresh token reuse detected" | ERR `OAuth refresh token reuse detected — family revoked` |
+| Reuse detected but revoke INSERT fails (security-critical) | 500 `server_error` "refresh state unavailable" | ERR `oauth_state: SECURITY: reuse detected but revoke INSERT failed — family is NOT revoked` |
+| Family revoked during pre-check→claim TOCTOU window | 400 `invalid_grant` "refresh token reuse detected" | (handled silently — claim slot is spent, no token minted, family already revoked) |
 | CH unreachable / RBAC denied / timeout         | 500 `server_error` "refresh state unavailable" | ERR `OAuth refresh state lookup failed — hard fail` |
 | Cleanup `ALTER DELETE` fails                   | (no user impact)           | WARN `oauth_state cleanup attempt failed (non-fatal)` |
 

--- a/docs/oauth-refresh-reuse-detection.md
+++ b/docs/oauth-refresh-reuse-detection.md
@@ -1,0 +1,195 @@
+# OAuth refresh-token reuse detection (H-2)
+
+This page documents the H-2 mitigation from the internal OAuth security
+review: how it works, what operators must do before turning it on, and how
+it fails. It is opt-in — set `oauth.refresh_revokes_tracking: true` only
+after running the operator prerequisites below.
+
+## Why this exists
+
+Without H-2, gating-mode refresh tokens are stateless JWE blobs. A captured
+refresh token can be redeemed many times — each redemption mints a fresh
+`access_token` + rotated `refresh_token` pair until the original JWE expires
+(default 30 days). An attacker who briefly captures a refresh JWE (leaked
+log, intermediate proxy, browser-extension compromise) gets a silent 30-day
+window of access against the legitimate user's identity.
+
+OAuth 2.1 §4.13.2 and the MCP authorization spec (2025-11-25) require
+*refresh-token rotation with reuse detection*: when a previously-redeemed
+token is presented again, the entire token *family* must be invalidated and
+the user forced to re-authenticate. RFC 6749 §10.4 frames the same
+requirement at SHOULD level for OAuth 2.0.
+
+H-2 closes the gap: the moment the legitimate client refreshes after the
+attacker (or vice-versa), the redeemed jti is in the consumed-set, the
+family is revoked, both parties are rejected on subsequent attempts, and
+the user re-authenticates once. The auth event is a clear signal.
+
+## How it works
+
+Every gating-mode refresh JWE carries two new claims:
+
+| Claim       | Lifecycle                                                       |
+| ----------- | --------------------------------------------------------------- |
+| `jti`       | Fresh 16-byte random hex per issuance. **Different every refresh.** |
+| `family_id` | Fresh 16-byte random hex at code→token exchange. **Stable across the entire rotation chain.** |
+
+```
+client → POST /oauth/token grant_type=authorization_code
+server → mint R1 { jti: A, family_id: F, ... }              [F is new]
+
+client → POST /oauth/token grant_type=refresh_token, R1
+server → check: A not in consumed, F not in revoked
+       → INSERT (jti=A, family_id=F) into consumed
+       → mint R2 { jti: B, family_id: F, ... }              [same F, new jti]
+
+client → POST /oauth/token grant_type=refresh_token, R2
+server → check: B not in consumed, F not in revoked
+       → INSERT (jti=B, family_id=F) into consumed
+       → mint R3 { jti: C, family_id: F, ... }
+```
+
+Reuse detection:
+
+```
+attacker steals R1 before client uses it.
+client legitimately refreshes R1 → R2 (A consumed, F still healthy)
+client refreshes R2 → R3 (B consumed)
+attacker now presents R1: server sees A already in consumed
+                        → INSERT (family_id=F, reason="reuse_detected") into revoked_families
+                        → reject this request with invalid_grant
+                        → next legit refresh of R3 sees F in revoked → also rejected
+                        → user re-auths from scratch
+```
+
+State lives in two ClickHouse tables in the `altinity` database. Both are
+append-only with `TTL ... + INTERVAL 35 DAY` so storage is bounded.
+
+| Table                                        | Purpose                                       | Lookup key  |
+| -------------------------------------------- | --------------------------------------------- | ----------- |
+| `altinity.oauth_refresh_consumed_jtis`       | Every redeemed refresh-token jti              | `jti`       |
+| `altinity.oauth_refresh_revoked_families`    | Families flagged after reuse detection        | `family_id` |
+
+Each refresh = 1 combined `SELECT count()` (two subqueries) + 1 `INSERT`.
+At realistic load (~hundreds of clients refreshing ~once per hour) that's
+on the order of 0.5 qps cluster-wide. Negligible.
+
+## Operator prerequisites
+
+Run [`docs/sql/oauth-state.sql`](sql/oauth-state.sql) against your
+ClickHouse cluster as an admin user **before** flipping the flag in helm
+values. The SQL file contains both the clustered (ReplicatedMergeTree) and
+single-node (MergeTree) flavors — uncomment the one you need.
+
+Pick clustered when:
+- Your CH is replicated (operator-managed CHI, multiple replicas).
+- You want the state to survive any single replica being down.
+
+Pick single-node when:
+- You're running a single CH server (e.g., a dev sandbox).
+- You only have one MCP pod.
+
+The Go code is engine-agnostic: SELECT and INSERT work the same on both.
+
+### Cluster name: `all-replicated` and why
+
+The DDL uses `ON CLUSTER 'all-replicated'` rather than the operator-default
+`{cluster}` macro. Reason: the primary cluster may be sharded across
+multiple physical clusters. OAuth state must live in a single logical shard
+so every MCP pod sees a consistent view of consumed jtis. By convention,
+`all-replicated` names a single shard spanning all replicas — operators
+configure this in the CHI's `<remote_servers>` block.
+
+If your CHI uses a different name for the all-replicas-single-shard
+cluster, edit `docs/sql/oauth-state.sql` to match. The Go code does not
+care about the cluster name; it only ever issues SELECT and INSERT.
+
+### `mcp_service` user and the `read_only` constraint
+
+The pool user (typically `mcp_service`) needs `INSERT, SELECT ON
+altinity.*`. The DDL adds the grant.
+
+**Important**: when `oauth.refresh_revokes_tracking: true`, the pool user
+**cannot** be read-only. Two checkpoints:
+
+1. **MCP-side**: `cfg.ClickHouse.read_only` must be `false`. Startup
+   validation refuses to boot if it's `true` while the flag is on.
+2. **CH-side**: the user's settings profile cannot include `readonly = 1`
+   (or `2`). The operator is responsible for this — there is no way for
+   MCP to inspect a profile from the client side without trying a write.
+   Verify:
+
+   ```sql
+   SELECT name, profile FROM system.users WHERE name = 'mcp_service';
+   SELECT name, value FROM system.settings_profiles
+   WHERE name IN (SELECT profile FROM system.users WHERE name = 'mcp_service');
+   ```
+
+   No row should set `readonly` to a non-zero value.
+
+If the pool user *is* read-only, the first refresh after enabling the flag
+will hard-fail with `server_error` and an ERR-level zerolog line. Roll
+back by flipping the flag to `false`; the refresh path returns to its
+stateless behavior.
+
+## Failure modes — hard fail with ERR
+
+Every CH-state failure path returns HTTP 500 `server_error` and emits an
+ERR-level zerolog line. We never silently fall through to "mint a new
+pair anyway" — that would defeat the security control.
+
+| Failure                                        | Response                  | Log                              |
+| ---------------------------------------------- | ------------------------- | -------------------------------- |
+| `mode: forward` + flag on                      | startup refuses to boot   | fatal startup error              |
+| `clickhouse.read_only: true` + flag on         | startup refuses to boot   | fatal startup error              |
+| Refresh JWE missing `jti` or `family_id` (legacy or malformed) | 400 `invalid_grant` "refresh token format unsupported, please re-authenticate" | ERR `OAuth refresh token rejected: missing jti or family_id` |
+| jti in `consumed_jtis` OR family in `revoked_families` (reuse) | 400 `invalid_grant` "refresh token reuse detected, please re-authenticate" | ERR `OAuth refresh token reuse detected — family revoked` |
+| CH unreachable / RBAC denied / timeout         | 500 `server_error` "refresh state unavailable" | ERR `OAuth refresh state lookup failed — hard fail` |
+
+## Legacy-token policy
+
+Refresh tokens issued before the flag flips lack the `jti` and `family_id`
+claims. They are rejected with `invalid_grant` on first redemption after
+deploy. Clients re-authenticate once.
+
+The alternative — auto-promote legacy tokens on first use — would let a
+captured pre-deploy token be replayed exactly once before the server
+starts tracking the family. We rejected that approach: a brief re-login
+is cheaper than a silent bypass window.
+
+## Rollback
+
+Set `oauth.refresh_revokes_tracking: false` in helm values, helm-upgrade.
+The refresh path returns to its current stateless behavior — no DB hit, no
+family-id propagation. In-flight refresh tokens that already carry the
+`jti`/`family_id` claims continue to work; the JWE whitelist accepts them
+even when the flag is off.
+
+The state tables can stay populated; TTL drops them in 35 days. There's
+no harm in leaving them — re-enabling the flag later picks up a clean
+table state plus whatever consumed jtis from the last 35 days are still
+relevant (most aren't, since each token's lifetime is 30 days).
+
+## Where the code lives
+
+| File                                                      | Role                                                     |
+| --------------------------------------------------------- | -------------------------------------------------------- |
+| `pkg/config/config.go`                                    | `OAuthConfig.RefreshRevokesTracking` field               |
+| `pkg/jwe_auth/jwe_auth.go`                                | `family_id` added to claims whitelist                    |
+| `pkg/oauth_state/store.go`                                | `Store` interface + ClickHouse implementation            |
+| `pkg/server/server_client.go`                             | `GetClickHouseSystemClient` (no oauth impersonation)     |
+| `pkg/server/server.go`                                    | Store wired onto `ClickHouseJWEServer` at construction   |
+| `cmd/altinity-mcp/main.go`                                | Startup validation + warnings                            |
+| `cmd/altinity-mcp/oauth_server.go`                        | Mint embeds `jti`/`family_id`; refresh handler enforces  |
+| `cmd/altinity-mcp/oauth_server_test.go`                   | Reuse-detection unit/integration tests                   |
+| `docs/sql/oauth-state.sql`                                | DDL + grant for operators                                |
+| `docs/oauth-refresh-reuse-detection.md`                   | This page                                                |
+
+## See also
+
+- `/Users/Workspaces/acm/mcp/.wiki/mcp-oauth-debugging.md` — operator wiki:
+  rollout checklist for each demo deployment + the original H-1/H-2
+  context.
+- [RFC 6749 §10.4 — Refresh Tokens](https://datatracker.ietf.org/doc/html/rfc6749#section-10.4)
+- [OAuth 2.1 (draft) §4.13.2 — Refresh Token Protection](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1)
+- [MCP authorization spec 2025-11-25](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)

--- a/docs/oauth-refresh-reuse-detection.md
+++ b/docs/oauth-refresh-reuse-detection.md
@@ -62,34 +62,101 @@ attacker now presents R1: server sees A already in consumed
                         → user re-auths from scratch
 ```
 
-State lives in two ClickHouse tables in the `altinity` database. Both are
-append-only with `TTL ... + INTERVAL 35 DAY` so storage is bounded.
+State lives in two ClickHouse tables in the `altinity` database:
 
-| Table                                        | Purpose                                       | Lookup key  |
-| -------------------------------------------- | --------------------------------------------- | ----------- |
-| `altinity.oauth_refresh_consumed_jtis`       | Every redeemed refresh-token jti              | `jti`       |
-| `altinity.oauth_refresh_revoked_families`    | Families flagged after reuse detection        | `family_id` |
+| Table                                        | Engine                  | Atomicity  | Cleanup                    |
+| -------------------------------------------- | ----------------------- | ---------- | -------------------------- |
+| `altinity.oauth_refresh_consumed_jtis`       | KeeperMap (strict mode) | linearizable | in-process `ALTER TABLE … DELETE` goroutine, hourly, 35-day retention |
+| `altinity.oauth_refresh_revoked_families`    | ReplicatedMergeTree     | (idempotent INSERT) | CH-native TTL, 35-day retention |
 
-Each refresh = 1 combined `SELECT count()` (two subqueries) + 1 `INSERT`.
-At realistic load (~hundreds of clients refreshing ~once per hour) that's
-on the order of 0.5 qps cluster-wide. Negligible.
+Each refresh = 1 cheap `SELECT count() FROM revoked_families` (point lookup
+by family_id) + 1 atomic `INSERT … SETTINGS keeper_map_strict_mode = 1`
+into consumed_jtis. At realistic load (~hundreds of clients refreshing
+~once per hour) that's on the order of 0.5 qps cluster-wide. Negligible.
+
+### Why KeeperMap and not just ReplicatedMergeTree
+
+The earlier H-2 design used `SELECT count() WHERE jti = ?` followed by
+`INSERT` into a `ReplicatedMergeTree` consumed-jtis table. That pattern
+is **not race-safe**: two parallel redemptions of the same captured
+refresh JWE both observe `count() = 0` on the SELECT, both succeed at
+the INSERT, and the family forks before any reuse is detected. From
+that point an attacker who steals a single token has their own valid
+branch of the family chain and never needs the original token again.
+
+KeeperMap (with `keeper_map_strict_mode=1`) is the fix. It's a key-value
+table engine backed by ClickHouse Keeper's Raft consensus. Concurrent
+INSERTs of the same primary key are serialised through the Keeper
+leader; exactly one wins, the rest receive `KEEPER_EXCEPTION:
+Transaction failed (Node exists)` (Code 999). The MCP store detects
+this signature and returns `ErrRefreshReused` to the handler, which
+records the family revocation and rejects the request. RFC 9700
+§refresh-token rotation: the server cannot tell which of two concurrent
+redeemers is legitimate, so the family dies on detection.
+
+KeeperMap doesn't add a Keeper dependency — `ReplicatedMergeTree` is
+already on Keeper for replication coordination. KeeperMap simply
+exposes the linearizable primitive Keeper already provides.
+
+### `keeper_map_strict_mode` is per-query
+
+ClickHouse silently ignores `SETTINGS keeper_map_strict_mode = 1` when
+declared at table-create time — only the per-query setting is honoured.
+The MCP binary applies it on every consumed-jti INSERT:
+
+```sql
+INSERT INTO altinity.oauth_refresh_consumed_jtis (jti, family_id)
+SETTINGS keeper_map_strict_mode = 1
+VALUES (?, ?)
+```
+
+If a future refactor drops the `SETTINGS` clause, duplicate INSERTs
+silently overwrite the existing row instead of erroring, and the
+atomicity property collapses. The clause is load-bearing.
 
 ## Operator prerequisites
 
-Run [`docs/sql/oauth-state.sql`](sql/oauth-state.sql) against your
-ClickHouse cluster as an admin user **before** flipping the flag in helm
-values. The SQL file contains both the clustered (ReplicatedMergeTree) and
-single-node (MergeTree) flavors — uncomment the one you need.
+Two steps, both as a CH admin user, **before** flipping the flag in helm
+values:
 
-Pick clustered when:
-- Your CH is replicated (operator-managed CHI, multiple replicas).
-- You want the state to survive any single replica being down.
+### 1. Enable KeeperMap (one-time per CH cluster)
 
-Pick single-node when:
-- You're running a single CH server (e.g., a dev sandbox).
-- You only have one MCP pod.
+KeeperMap requires `<keeper_map_path_prefix>` in the CH server config.
+Without it, `CREATE TABLE … ENGINE = KeeperMap` fails with
+`Code: 36. KeeperMap is disabled because 'keeper_map_path_prefix' config
+is not defined`.
 
-The Go code is engine-agnostic: SELECT and INSERT work the same on both.
+Add a `config.d` drop-in:
+
+```xml
+<clickhouse>
+    <keeper_map_path_prefix>/altinity_mcp/keeper_map</keeper_map_path_prefix>
+</clickhouse>
+```
+
+For ACM-managed CHIs the setting name is `config.d/keeper_map.xml` —
+`acmctl raw POST /cluster/<id>/settings` (with name+value+description as
+JSON body via stdin) followed by `acmctl raw POST /cluster/<id>/push`.
+The CH pod restarts automatically after push (~30–60 s).
+
+Verify:
+
+```sql
+CREATE TABLE default.kmap_smoke (k String) ENGINE = KeeperMap('/altinity_mcp/smoke') PRIMARY KEY k;
+DROP TABLE default.kmap_smoke;
+```
+
+Both should succeed.
+
+### 2. Run the DDL
+
+[`docs/sql/oauth-state.sql`](sql/oauth-state.sql) creates the `altinity`
+database, both tables, and grants `INSERT, SELECT, ALTER DELETE ON
+altinity.* TO mcp_service`.
+
+The MCP binary is engine-aware: KeeperMap for consumed_jtis,
+ReplicatedMergeTree for revoked_families. Mixing engines is intentional
+(see "Why KeeperMap and not just ReplicatedMergeTree" above).
 
 ### Cluster name: `all-replicated` and why
 
@@ -106,8 +173,15 @@ care about the cluster name; it only ever issues SELECT and INSERT.
 
 ### `mcp_service` user and the `read_only` constraint
 
-The pool user (typically `mcp_service`) needs `INSERT, SELECT ON
-altinity.*`. The DDL adds the grant.
+The pool user (typically `mcp_service`) needs `INSERT, SELECT, ALTER
+DELETE ON altinity.*`. The DDL adds the grant.
+
+`ALTER DELETE` is needed because KeeperMap doesn't support CH-native
+TTL — the MCP binary runs `ALTER TABLE altinity.oauth_refresh_consumed_jtis
+DELETE WHERE consumed_at < now() - INTERVAL 35 DAY` from an in-process
+goroutine on an hourly ticker (see `pkg/oauth_state/cleanup.go`). Multi-pod
+deployments all run their own loops; duplicate `ALTER DELETE`s are
+harmless.
 
 **Important**: when `oauth.refresh_revokes_tracking: true`, the pool user
 **cannot** be read-only. Two checkpoints:
@@ -142,9 +216,12 @@ pair anyway" — that would defeat the security control.
 | ---------------------------------------------- | ------------------------- | -------------------------------- |
 | `mode: forward` + flag on                      | startup refuses to boot   | fatal startup error              |
 | `clickhouse.read_only: true` + flag on         | startup refuses to boot   | fatal startup error              |
+| `keeper_map_path_prefix` not configured CH-side | first refresh attempt    | 500 `server_error`; ERR with `KeeperMap is disabled` |
 | Refresh JWE missing `jti` or `family_id` (legacy or malformed) | 400 `invalid_grant` "refresh token format unsupported, please re-authenticate" | ERR `OAuth refresh token rejected: missing jti or family_id` |
-| jti in `consumed_jtis` OR family in `revoked_families` (reuse) | 400 `invalid_grant` "refresh token reuse detected, please re-authenticate" | ERR `OAuth refresh token reuse detected — family revoked` |
+| Family already in `revoked_families` (legitimate owner refreshing post-revocation) | 400 `invalid_grant` "refresh token reuse detected" | ERR `OAuth refresh token reuse detected — family revoked` |
+| Concurrent or sequential jti replay (KeeperMap dup-key) | 400 `invalid_grant` "refresh token reuse detected" | ERR `OAuth refresh token reuse detected — family revoked` |
 | CH unreachable / RBAC denied / timeout         | 500 `server_error` "refresh state unavailable" | ERR `OAuth refresh state lookup failed — hard fail` |
+| Cleanup `ALTER DELETE` fails                   | (no user impact)           | WARN `oauth_state cleanup attempt failed (non-fatal)` |
 
 ## Legacy-token policy
 
@@ -176,7 +253,8 @@ relevant (most aren't, since each token's lifetime is 30 days).
 | --------------------------------------------------------- | -------------------------------------------------------- |
 | `pkg/config/config.go`                                    | `OAuthConfig.RefreshRevokesTracking` field               |
 | `pkg/jwe_auth/jwe_auth.go`                                | `family_id` added to claims whitelist                    |
-| `pkg/oauth_state/store.go`                                | `Store` interface + ClickHouse implementation            |
+| `pkg/oauth_state/store.go`                                | `Store` interface + KeeperMap-backed implementation, atomic claim semantics |
+| `pkg/oauth_state/cleanup.go`                              | TTL-replacement cleanup goroutine for KeeperMap consumed-jtis |
 | `pkg/server/server_client.go`                             | `GetClickHouseSystemClient` (no oauth impersonation)     |
 | `pkg/server/server.go`                                    | Store wired onto `ClickHouseJWEServer` at construction   |
 | `cmd/altinity-mcp/main.go`                                | Startup validation + warnings                            |

--- a/docs/sql/oauth-state.sql
+++ b/docs/sql/oauth-state.sql
@@ -1,41 +1,61 @@
 -- Altinity MCP — OAuth refresh-token reuse-detection state (H-2).
 --
--- One database, two append-only tables, one role grant. Run this on the
--- ClickHouse cluster BEFORE flipping `oauth.refresh_revokes_tracking: true`
--- in the MCP helm values. Run as an admin user (the pool user `mcp_service`
--- intentionally lacks CREATE privileges).
+-- Two tables: KeeperMap-backed consumed-jti store (atomic insert-or-error,
+-- exactly-one-winner across MCP pods via ClickHouse Keeper Raft consensus)
+-- and a ReplicatedMergeTree revoked-families log. Run this on the cluster
+-- BEFORE flipping `oauth.refresh_revokes_tracking: true` in helm values.
+-- Run as an admin user (the pool user `mcp_service` intentionally lacks
+-- CREATE privileges).
 --
 -- See docs/oauth-refresh-reuse-detection.md for the full design rationale,
 -- threat model, and operator-side knobs.
 --
--- Two flavors below:
---   1. Clustered (ON CLUSTER 'all-replicated' + ReplicatedMergeTree)
---   2. Single-node (plain MergeTree)
--- Pick exactly one block and run it; the binary doesn't care which engine,
--- only that the schema matches.
---
 -- The cluster name `all-replicated` is conventional for a single logical
--- shard spanning all replicas. We deliberately avoid the `{cluster}` macro
--- because the primary cluster may be sharded; OAuth state belongs in a
--- single shard so SELECT count() / INSERT see a consistent view across
--- all MCP pods.
+-- shard spanning all replicas. OAuth state belongs in a single shard so
+-- KeeperMap entries (one per consumed jti) are visible to every MCP pod
+-- without cross-shard hops.
 
 ----------------------------------------------------------------------
--- Flavor 1: Clustered (ReplicatedMergeTree, multi-replica)
+-- Operator prerequisite (BLOCKING):
+--
+-- KeeperMap requires <keeper_map_path_prefix> in CH server config. Add a
+-- config.d drop-in:
+--
+--     <clickhouse>
+--         <keeper_map_path_prefix>/altinity_mcp/keeper_map</keeper_map_path_prefix>
+--     </clickhouse>
+--
+-- (For ACM-managed clusters: setting name `config.d/keeper_map.xml`.)
+-- Without this, CREATE TABLE … ENGINE = KeeperMap fails with
+-- "KeeperMap is disabled because 'keeper_map_path_prefix' config is not
+-- defined" (BAD_ARGUMENTS, code 36).
+----------------------------------------------------------------------
+
+----------------------------------------------------------------------
+-- Flavor 1: Clustered (KeeperMap + ReplicatedMergeTree)
 ----------------------------------------------------------------------
 
 CREATE DATABASE IF NOT EXISTS altinity ON CLUSTER 'all-replicated';
 
+-- Atomic claim store. The MCP binary issues every INSERT with
+-- `SETTINGS keeper_map_strict_mode = 1`, which makes Keeper reject
+-- duplicate primary-key transactions with a KEEPER_EXCEPTION. The
+-- table-level SETTINGS clause below is COSMETIC — CH silently ignores
+-- `keeper_map_strict_mode` at table-create time; only the per-query
+-- setting is honoured. The DDL keeps it for documentation.
 CREATE TABLE IF NOT EXISTS altinity.oauth_refresh_consumed_jtis ON CLUSTER 'all-replicated'
 (
     jti         String,
     family_id   String,
     consumed_at DateTime DEFAULT now()
 )
-ENGINE = ReplicatedMergeTree
-ORDER BY jti
-TTL consumed_at + INTERVAL 35 DAY;
+ENGINE = KeeperMap('/altinity_mcp/oauth_refresh_consumed_jtis')
+PRIMARY KEY jti
+SETTINGS keeper_map_strict_mode = 1;  -- documentation only; query-level is what enforces
 
+-- Revoked-families audit log. Plain ReplicatedMergeTree — INSERTs are
+-- idempotent (multiple parallel revokes of the same family collapse via
+-- TTL), and CH-native TTL handles cleanup automatically.
 CREATE TABLE IF NOT EXISTS altinity.oauth_refresh_revoked_families ON CLUSTER 'all-replicated'
 (
     family_id  String,
@@ -46,11 +66,24 @@ ENGINE = ReplicatedMergeTree
 ORDER BY family_id
 TTL revoked_at + INTERVAL 35 DAY;
 
-GRANT INSERT, SELECT ON altinity.* TO mcp_service ON CLUSTER 'all-replicated';
+-- Grants needed by the MCP pool user.
+--   INSERT — both tables (claim a jti, log a revoke).
+--   SELECT — revoked_families lookup before claiming.
+--   ALTER DELETE — the in-process cleanup loop runs ALTER TABLE … DELETE
+--                  WHERE consumed_at < now() - INTERVAL 35 DAY against
+--                  the KeeperMap consumed_jtis table (KeeperMap doesn't
+--                  support TTL natively).
+GRANT INSERT, SELECT, ALTER DELETE ON altinity.* TO mcp_service ON CLUSTER 'all-replicated';
 
 ----------------------------------------------------------------------
--- Flavor 2: Single-node (MergeTree, no replication)
+-- Flavor 2: Single-node (KeeperMap + MergeTree)
 ----------------------------------------------------------------------
+-- KeeperMap requires Keeper. If you have a Keeper service available
+-- (even a single-node embedded keeper), this flavor still applies. If
+-- you have NO Keeper at all, H-2 cannot run as designed — the security
+-- property requires linearizable claim semantics that no single-node
+-- engine provides. In that case keep `oauth.refresh_revokes_tracking`
+-- disabled and accept the residual risk documented in the H-2 doc.
 
 -- CREATE DATABASE IF NOT EXISTS altinity;
 --
@@ -60,9 +93,9 @@ GRANT INSERT, SELECT ON altinity.* TO mcp_service ON CLUSTER 'all-replicated';
 --     family_id   String,
 --     consumed_at DateTime DEFAULT now()
 -- )
--- ENGINE = MergeTree
--- ORDER BY jti
--- TTL consumed_at + INTERVAL 35 DAY;
+-- ENGINE = KeeperMap('/altinity_mcp/oauth_refresh_consumed_jtis')
+-- PRIMARY KEY jti
+-- SETTINGS keeper_map_strict_mode = 1;
 --
 -- CREATE TABLE IF NOT EXISTS altinity.oauth_refresh_revoked_families
 -- (
@@ -74,17 +107,33 @@ GRANT INSERT, SELECT ON altinity.* TO mcp_service ON CLUSTER 'all-replicated';
 -- ORDER BY family_id
 -- TTL revoked_at + INTERVAL 35 DAY;
 --
--- GRANT INSERT, SELECT ON altinity.* TO mcp_service;
+-- GRANT INSERT, SELECT, ALTER DELETE ON altinity.* TO mcp_service;
 
 ----------------------------------------------------------------------
 -- Verification (run as the same admin user)
 ----------------------------------------------------------------------
 --
 --   SHOW GRANTS FOR mcp_service;
---   -- expect: GRANT INSERT, SELECT ON altinity.* TO mcp_service
+--   -- expect: GRANT INSERT, SELECT, ALTER DELETE ON altinity.* TO mcp_service
+--
+--   -- Confirm KeeperMap is enabled (path_prefix configured):
+--   CREATE TABLE default.kmap_smoke (k String) ENGINE = KeeperMap('/altinity_mcp/smoke')
+--       PRIMARY KEY k SETTINGS keeper_map_strict_mode=1;
+--   DROP TABLE default.kmap_smoke;
+--   -- both should succeed; the first throws BAD_ARGUMENTS (code 36)
+--   -- "KeeperMap is disabled" if the operator prerequisite is unmet.
+--
+--   -- Confirm strict-mode rejects duplicate INSERTs (must be set per-query
+--   -- — table-level SETTINGS is silently ignored for keeper_map_strict_mode):
+--   CREATE TABLE default.kmap_strict_smoke (k String, v String)
+--       ENGINE = KeeperMap('/altinity_mcp/strict_smoke') PRIMARY KEY k;
+--   INSERT INTO default.kmap_strict_smoke VALUES ('a', '1');  -- ok
+--   INSERT INTO default.kmap_strict_smoke
+--       SETTINGS keeper_map_strict_mode = 1
+--       VALUES ('a', '2');
+--   -- expect: Code 999 KEEPER_EXCEPTION "Transaction failed (Node exists)"
+--   DROP TABLE default.kmap_strict_smoke;
 --
 --   -- Confirm mcp_service is NOT readonly (H-2 requires write access):
---   SELECT name, profile FROM system.users WHERE name = 'mcp_service';
---   SELECT * FROM system.settings_profiles WHERE name IN
---       (SELECT profile FROM system.users WHERE name = 'mcp_service');
---   -- expect: no `readonly` setting >= 1 in any inherited profile.
+--   SELECT name, default_roles_list FROM system.users WHERE name = 'mcp_service';
+--   -- and check that no inherited settings profile sets readonly >= 1.

--- a/docs/sql/oauth-state.sql
+++ b/docs/sql/oauth-state.sql
@@ -1,11 +1,25 @@
 -- Altinity MCP — OAuth refresh-token reuse-detection state (H-2).
 --
--- Two tables: KeeperMap-backed consumed-jti store (atomic insert-or-error,
--- exactly-one-winner across MCP pods via ClickHouse Keeper Raft consensus)
--- and a ReplicatedMergeTree revoked-families log. Run this on the cluster
--- BEFORE flipping `oauth.refresh_revokes_tracking: true` in helm values.
--- Run as an admin user (the pool user `mcp_service` intentionally lacks
--- CREATE privileges).
+-- Two KeeperMap tables, both linearizable via ClickHouse Keeper Raft:
+--
+--   - consumed_jtis: atomic insert-or-error (exactly-one-winner across
+--     MCP pods regardless of which CH replica each pod talks to). Strict
+--     mode is set per-INSERT in the Go code; without it concurrent
+--     redemptions of the same captured refresh token both succeed and
+--     the family forks before any reuse is detected.
+--
+--   - revoked_families: also KeeperMap. The refresh path checks this
+--     table BEFORE allowing a refresh; if it were ReplicatedMergeTree,
+--     async replication would let the WINNER of a forked family keep
+--     refreshing its branch on a CH replica that hasn't yet seen the
+--     loser's revoke INSERT. KeeperMap reads are linearizable, so the
+--     revoke is visible to every MCP pod immediately after Keeper
+--     consensus. Idempotent overwrite on duplicate family_id (no strict
+--     mode) — multiple parallel losers writing the same family is fine.
+--
+-- Run this on the cluster BEFORE flipping `oauth.refresh_revokes_tracking:
+-- true` in helm values. Run as an admin user (the pool user `mcp_service`
+-- intentionally lacks CREATE privileges).
 --
 -- See docs/oauth-refresh-reuse-detection.md for the full design rationale,
 -- threat model, and operator-side knobs.
@@ -53,18 +67,22 @@ ENGINE = KeeperMap('/altinity_mcp/oauth_refresh_consumed_jtis')
 PRIMARY KEY jti
 SETTINGS keeper_map_strict_mode = 1;  -- documentation only; query-level is what enforces
 
--- Revoked-families audit log. Plain ReplicatedMergeTree — INSERTs are
--- idempotent (multiple parallel revokes of the same family collapse via
--- TTL), and CH-native TTL handles cleanup automatically.
+-- Revoked-families enforcement table. KeeperMap (linearizable reads) so
+-- that a revoke on pod A is visible to pod B's next refresh-path read
+-- regardless of which CH replica each pod talks to. Idempotent overwrite
+-- on duplicate family_id (no strict mode here) — parallel losers writing
+-- the same revoke is fine; the second write replaces the reason field
+-- with whichever loser was scheduled last. KeeperMap doesn't support
+-- CH-native TTL, so cleanup is application-side via ALTER TABLE …
+-- DELETE in the MCP cleanup goroutine.
 CREATE TABLE IF NOT EXISTS altinity.oauth_refresh_revoked_families ON CLUSTER 'all-replicated'
 (
     family_id  String,
     revoked_at DateTime DEFAULT now(),
     reason     LowCardinality(String)
 )
-ENGINE = ReplicatedMergeTree
-ORDER BY family_id
-TTL revoked_at + INTERVAL 35 DAY;
+ENGINE = KeeperMap('/altinity_mcp/oauth_refresh_revoked_families')
+PRIMARY KEY family_id;
 
 -- Grants needed by the MCP pool user.
 --   INSERT — both tables (claim a jti, log a revoke).
@@ -103,9 +121,8 @@ GRANT INSERT, SELECT, ALTER DELETE ON altinity.* TO mcp_service ON CLUSTER 'all-
 --     revoked_at DateTime DEFAULT now(),
 --     reason     LowCardinality(String)
 -- )
--- ENGINE = MergeTree
--- ORDER BY family_id
--- TTL revoked_at + INTERVAL 35 DAY;
+-- ENGINE = KeeperMap('/altinity_mcp/oauth_refresh_revoked_families')
+-- PRIMARY KEY family_id;
 --
 -- GRANT INSERT, SELECT, ALTER DELETE ON altinity.* TO mcp_service;
 

--- a/docs/sql/oauth-state.sql
+++ b/docs/sql/oauth-state.sql
@@ -1,0 +1,90 @@
+-- Altinity MCP — OAuth refresh-token reuse-detection state (H-2).
+--
+-- One database, two append-only tables, one role grant. Run this on the
+-- ClickHouse cluster BEFORE flipping `oauth.refresh_revokes_tracking: true`
+-- in the MCP helm values. Run as an admin user (the pool user `mcp_service`
+-- intentionally lacks CREATE privileges).
+--
+-- See docs/oauth-refresh-reuse-detection.md for the full design rationale,
+-- threat model, and operator-side knobs.
+--
+-- Two flavors below:
+--   1. Clustered (ON CLUSTER 'all-replicated' + ReplicatedMergeTree)
+--   2. Single-node (plain MergeTree)
+-- Pick exactly one block and run it; the binary doesn't care which engine,
+-- only that the schema matches.
+--
+-- The cluster name `all-replicated` is conventional for a single logical
+-- shard spanning all replicas. We deliberately avoid the `{cluster}` macro
+-- because the primary cluster may be sharded; OAuth state belongs in a
+-- single shard so SELECT count() / INSERT see a consistent view across
+-- all MCP pods.
+
+----------------------------------------------------------------------
+-- Flavor 1: Clustered (ReplicatedMergeTree, multi-replica)
+----------------------------------------------------------------------
+
+CREATE DATABASE IF NOT EXISTS altinity ON CLUSTER 'all-replicated';
+
+CREATE TABLE IF NOT EXISTS altinity.oauth_refresh_consumed_jtis ON CLUSTER 'all-replicated'
+(
+    jti         String,
+    family_id   String,
+    consumed_at DateTime DEFAULT now()
+)
+ENGINE = ReplicatedMergeTree
+ORDER BY jti
+TTL consumed_at + INTERVAL 35 DAY;
+
+CREATE TABLE IF NOT EXISTS altinity.oauth_refresh_revoked_families ON CLUSTER 'all-replicated'
+(
+    family_id  String,
+    revoked_at DateTime DEFAULT now(),
+    reason     LowCardinality(String)
+)
+ENGINE = ReplicatedMergeTree
+ORDER BY family_id
+TTL revoked_at + INTERVAL 35 DAY;
+
+GRANT INSERT, SELECT ON altinity.* TO mcp_service ON CLUSTER 'all-replicated';
+
+----------------------------------------------------------------------
+-- Flavor 2: Single-node (MergeTree, no replication)
+----------------------------------------------------------------------
+
+-- CREATE DATABASE IF NOT EXISTS altinity;
+--
+-- CREATE TABLE IF NOT EXISTS altinity.oauth_refresh_consumed_jtis
+-- (
+--     jti         String,
+--     family_id   String,
+--     consumed_at DateTime DEFAULT now()
+-- )
+-- ENGINE = MergeTree
+-- ORDER BY jti
+-- TTL consumed_at + INTERVAL 35 DAY;
+--
+-- CREATE TABLE IF NOT EXISTS altinity.oauth_refresh_revoked_families
+-- (
+--     family_id  String,
+--     revoked_at DateTime DEFAULT now(),
+--     reason     LowCardinality(String)
+-- )
+-- ENGINE = MergeTree
+-- ORDER BY family_id
+-- TTL revoked_at + INTERVAL 35 DAY;
+--
+-- GRANT INSERT, SELECT ON altinity.* TO mcp_service;
+
+----------------------------------------------------------------------
+-- Verification (run as the same admin user)
+----------------------------------------------------------------------
+--
+--   SHOW GRANTS FOR mcp_service;
+--   -- expect: GRANT INSERT, SELECT ON altinity.* TO mcp_service
+--
+--   -- Confirm mcp_service is NOT readonly (H-2 requires write access):
+--   SELECT name, profile FROM system.users WHERE name = 'mcp_service';
+--   SELECT * FROM system.settings_profiles WHERE name IN
+--       (SELECT profile FROM system.users WHERE name = 'mcp_service');
+--   -- expect: no `readonly` setting >= 1 in any inherited profile.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -176,6 +176,14 @@ type OAuthConfig struct {
 	// RequireEmailVerified rejects identities where email_verified is false when an email claim is present.
 	RequireEmailVerified bool `json:"require_email_verified" yaml:"require_email_verified" flag:"oauth-require-email-verified" env:"MCP_OAUTH_REQUIRE_EMAIL_VERIFIED" desc:"Require email_verified=true on OAuth identities"`
 
+	// RefreshRevokesTracking enables refresh-token reuse detection (H-2).
+	// When true, every gating-mode refresh-token issuance carries a fresh jti
+	// and a stable family_id; redemption checks the consumed-jti / revoked-
+	// family tables in the `altinity` ClickHouse database and revokes the
+	// entire family if reuse is detected. Requires gating mode + a writable
+	// mcp_service CH connection (see docs/oauth-refresh-reuse-detection.md).
+	RefreshRevokesTracking bool `json:"refresh_revokes_tracking" yaml:"refresh_revokes_tracking" flag:"oauth-refresh-revokes-tracking" env:"MCP_OAUTH_REFRESH_REVOKES_TRACKING" desc:"Enable refresh-token reuse detection backed by ClickHouse (H-2)"`
+
 	// RegistrationPath configures the relative path for dynamic client registration.
 	RegistrationPath string `json:"registration_path" yaml:"registration_path" flag:"oauth-registration-path" env:"MCP_OAUTH_REGISTRATION_PATH" desc:"Relative path for OAuth client registration endpoint"`
 

--- a/pkg/jwe_auth/jwe_auth.go
+++ b/pkg/jwe_auth/jwe_auth.go
@@ -270,6 +270,10 @@ func validateClaimsWhitelist(claims map[string]interface{}) error {
 		"name":                       true,
 		"hd":                         true,
 		"email_verified":             true,
+
+		// H-2 refresh-token reuse detection: stable across the rotation chain.
+		// jti is already covered above (JWT-standard).
+		"family_id": true,
 	}
 
 	// Check for any disallowed keys

--- a/pkg/oauth_state/cleanup.go
+++ b/pkg/oauth_state/cleanup.go
@@ -1,0 +1,99 @@
+package oauth_state
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// DefaultCleanupInterval is the wakeup cadence for the consumed-jti cleanup
+// goroutine. Hourly is conservative — KeeperMap entries are tiny (~80 bytes)
+// and our scale (~hundreds of clients refreshing ~1×/h) produces a few
+// thousand new entries per day even before TTL bites. Hourly DELETEs keep
+// the table bounded with no perceptible CH load. Operators can override.
+const DefaultCleanupInterval = 1 * time.Hour
+
+// DefaultCleanupRetention is how long a consumed-jti row sticks around. 35
+// days = the gating-mode refresh-token TTL (30 days) plus a 5-day buffer
+// for clock skew and replay-window bounds. After this point the rows are
+// safe to delete: any refresh JWE that could still reference the jti has
+// itself expired (its `exp` is unconditionally checked in
+// decodeOAuthJWE before CheckAndConsume runs).
+const DefaultCleanupRetention = 35 * 24 * time.Hour
+
+// CleanupRunner is the subset of Store that the loop needs. Defining it
+// separately lets tests inject a counter without standing up a CH harness.
+type CleanupRunner interface {
+	Cleanup(ctx context.Context, retention time.Duration) error
+}
+
+// StartCleanupLoop spawns a goroutine that periodically deletes consumed-
+// jti rows older than `retention`. The goroutine exits when ctx is
+// cancelled. Each cleanup attempt is bounded by `attemptTimeout`; failures
+// are logged but never panic, so the loop is durable across CH outages.
+//
+// Multi-pod deployments all run their own loops — duplicate `ALTER DELETE`s
+// are harmless (CH coalesces; KeeperMap deletes are idempotent on absent
+// keys).
+//
+// Returns a "stop" function for tests; in production the caller passes a
+// server-lifetime context and the returned function is rarely called.
+func StartCleanupLoop(ctx context.Context, runner CleanupRunner, interval, retention, attemptTimeout time.Duration) func() {
+	if interval <= 0 {
+		interval = DefaultCleanupInterval
+	}
+	if retention <= 0 {
+		retention = DefaultCleanupRetention
+	}
+	if attemptTimeout <= 0 {
+		attemptTimeout = 5 * time.Minute
+	}
+
+	loopCtx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		log.Info().
+			Dur("interval", interval).
+			Dur("retention", retention).
+			Msg("oauth_state cleanup loop started")
+		defer log.Info().Msg("oauth_state cleanup loop stopped")
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-loopCtx.Done():
+				return
+			case <-ticker.C:
+				runOnce(loopCtx, runner, retention, attemptTimeout)
+			}
+		}
+	}()
+
+	return cancel
+}
+
+// runOnce executes a single cleanup attempt with a per-attempt timeout.
+// Errors are logged at WARN; we never escalate to ERR because cleanup
+// failure does not affect the security control (KeeperMap atomicity is
+// what enforces single-claim, not the cleanup). Cleanup is just bounded-
+// storage hygiene.
+func runOnce(parentCtx context.Context, runner CleanupRunner, retention, attemptTimeout time.Duration) {
+	attemptCtx, cancel := context.WithTimeout(parentCtx, attemptTimeout)
+	defer cancel()
+
+	if err := runner.Cleanup(attemptCtx, retention); err != nil {
+		// Don't log if the parent context was cancelled — that's an
+		// orderly shutdown, not a failure.
+		if errors.Is(err, context.Canceled) || errors.Is(parentCtx.Err(), context.Canceled) {
+			return
+		}
+		log.Warn().
+			Err(err).
+			Dur("retention", retention).
+			Msg("oauth_state cleanup attempt failed (non-fatal)")
+	}
+}

--- a/pkg/oauth_state/store.go
+++ b/pkg/oauth_state/store.go
@@ -5,16 +5,23 @@
 //
 //  1. Calls Store.CheckAndConsume with the presented refresh token's jti
 //     and family_id.
-//  2. If the jti was already in the consumed-jti table OR the family_id was
-//     already in the revoked-families table, the entire family is revoked
-//     and ErrRefreshReused is returned. The handler must reject the request.
-//  3. Otherwise, the jti is recorded as consumed and the handler mints a
-//     fresh access+refresh pair sharing the same family_id with a new jti.
+//  2. The store fast-rejects if the family is already in the revoked-
+//     families table.
+//  3. Otherwise it attempts to atomically claim the jti by INSERTing into
+//     the KeeperMap-backed consumed-jti table (with strict mode, duplicate
+//     PRIMARY KEY throws an exception). On success the caller mints a new
+//     access+refresh pair sharing the same family_id with a new jti. On
+//     duplicate-key error the family is recorded as revoked and
+//     ErrRefreshReused is returned.
 //
-// The implementation is intentionally minimal: two ClickHouse tables in the
-// `altinity` database, each Replicated|MergeTree with TTL 35 days. Operators
-// pre-create the schema (see docs/sql/oauth-state.sql) — the binary never
-// issues DDL.
+// Atomicity property: KeeperMap with `keeper_map_strict_mode=1` provides
+// linearizable, exactly-one-winner INSERT across MCP pods regardless of
+// which CH replica each pod connects to. This is what closes the parallel-
+// replay window that the previous SELECT-then-INSERT design left open.
+//
+// Operators pre-create the schema (see docs/sql/oauth-state.sql) — the
+// binary never issues DDL. KeeperMap requires `<keeper_map_path_prefix>`
+// in CH server config; without it CREATE TABLE fails at deploy time.
 package oauth_state
 
 import (
@@ -22,27 +29,41 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
+	"time"
 
 	"github.com/altinity/altinity-mcp/pkg/clickhouse"
+	"github.com/rs/zerolog/log"
 )
 
 // ErrRefreshReused signals that the presented refresh token's jti was
-// already consumed or its family was already revoked. The store has
-// recorded the family in oauth_refresh_revoked_families before returning
-// this error. Callers must reject the refresh with `invalid_grant`.
+// already consumed or its family was already revoked. The store
+// best-effort records the family in oauth_refresh_revoked_families
+// before returning this error. Callers must reject the refresh with
+// `invalid_grant`.
 var ErrRefreshReused = errors.New("oauth_state: refresh token reuse detected, family revoked")
 
 // Store handles OAuth refresh-token reuse detection.
 type Store interface {
-	// CheckAndConsume looks up the jti + family_id, marks the family
-	// revoked on a hit, or marks the jti consumed on a miss.
+	// CheckAndConsume tries to atomically claim the (jti, family_id) pair.
+	//
+	//   - Returns nil on a fresh redemption: the jti is now recorded as
+	//     consumed (linearizable-claimed via KeeperMap strict mode).
+	//     Caller mints new tokens.
+	//   - Returns ErrRefreshReused if the family is already revoked OR
+	//     another concurrent claimant won the race for this jti. The
+	//     family is best-effort recorded in revoked_families.
+	//   - Returns a wrapped CH error on infrastructure failure (caller
+	//     hard-fails with HTTP 500 server_error).
 	//
 	// `reason` is recorded in oauth_refresh_revoked_families for audit;
 	// suggested values: "reuse_detected", "manual_revoke".
-	//
-	// Returns ErrRefreshReused on reuse, nil on a fresh redemption,
-	// or a wrapped CH error on infrastructure failure (caller hard-fails).
 	CheckAndConsume(ctx context.Context, jti, familyID, reason string) error
+
+	// Cleanup deletes consumed-jti rows older than the given retention
+	// window. Bounded operation, idempotent across pods. Returns the CH
+	// error verbatim so callers can decide whether to log or escalate.
+	Cleanup(ctx context.Context, retention time.Duration) error
 }
 
 // CHClient is the subset of *clickhouse.Client used by chStore. It exists
@@ -75,19 +96,29 @@ const (
 	revokedFamiliesTable = "altinity.oauth_refresh_revoked_families"
 )
 
-// Combined existence check: one round trip yields both consumed-jti and
-// revoked-family counts. Subqueries each use the table's primary-key
-// index (ORDER BY jti / ORDER BY family_id), so each is a sparse-index
-// lookup, not a scan.
-const checkQuery = `
-SELECT
-    (SELECT count() FROM ` + consumedJtisTable + ` WHERE jti = ?) AS consumed,
-    (SELECT count() FROM ` + revokedFamiliesTable + ` WHERE family_id = ?) AS revoked
-`
+// selectRevokedQuery returns 1 if the family is already revoked, 0 otherwise.
+// Cheap point-lookup (ORDER BY family_id) on a small ReplicatedMergeTree.
+const selectRevokedQuery = `SELECT count() FROM ` + revokedFamiliesTable + ` WHERE family_id = ?`
 
-const insertConsumedQuery = `INSERT INTO ` + consumedJtisTable + ` (jti, family_id) VALUES (?, ?)`
+// insertConsumedQuery atomically claims a jti slot in the KeeperMap-backed
+// table. `keeper_map_strict_mode` MUST be set on the INSERT statement
+// itself — CH silently ignores the table-level SETTINGS clause for this
+// flag, so without query-level enforcement a duplicate INSERT silently
+// overwrites instead of erroring (verified empirically against CH 26.1.6).
+// Without strict mode, the entire atomicity property of this design
+// collapses; the SETTINGS clause below is load-bearing.
+//
+// On a duplicate primary key, CH raises a KEEPER_EXCEPTION with text
+// "Transaction failed (Node exists)" — detected by isKeeperMapDuplicateKeyError.
+const insertConsumedQuery = `INSERT INTO ` + consumedJtisTable + ` (jti, family_id) ` +
+	`SETTINGS keeper_map_strict_mode = 1 VALUES (?, ?)`
 
 const insertRevokedQuery = `INSERT INTO ` + revokedFamiliesTable + ` (family_id, reason) VALUES (?, ?)`
+
+// deleteOldConsumedQuery is the cleanup statement: KeeperMap doesn't support
+// CH-native TTL, so we run this on a goroutine ticker. Uses INTERVAL with a
+// bound seconds value (driver-side parametrization).
+const deleteOldConsumedQuery = `ALTER TABLE ` + consumedJtisTable + ` DELETE WHERE consumed_at < now() - toIntervalSecond(?)`
 
 func (s *chStore) CheckAndConsume(ctx context.Context, jti, familyID, reason string) error {
 	if jti == "" || familyID == "" {
@@ -100,50 +131,108 @@ func (s *chStore) CheckAndConsume(ctx context.Context, jti, familyID, reason str
 	}
 	defer func() { _ = cli.Close() }()
 
-	res, err := cli.ExecuteQuery(ctx, checkQuery, jti, familyID)
+	// 1. Cheap revocation check. If the family is already in
+	// revoked_families, fast-reject without burning a KeeperMap slot.
+	// Catches the case where a prior race-loser pod revoked the family
+	// and the legitimate owner is now refreshing.
+	revoked, err := s.familyRevoked(ctx, cli, familyID)
 	if err != nil {
-		return fmt.Errorf("oauth_state: select consumed/revoked: %w", err)
+		return fmt.Errorf("oauth_state: select revoked: %w", err)
 	}
-	if res == nil || res.Count != 1 || len(res.Rows) != 1 || len(res.Rows[0]) < 2 {
-		return fmt.Errorf("oauth_state: unexpected select shape (count=%d rows=%d cols=%d)",
-			func() int {
-				if res == nil {
-					return 0
-				}
-				return res.Count
-			}(),
-			func() int {
-				if res == nil {
-					return 0
-				}
-				return len(res.Rows)
-			}(),
-			func() int {
-				if res == nil || len(res.Rows) == 0 {
-					return 0
-				}
-				return len(res.Rows[0])
-			}())
+	if revoked {
+		return ErrRefreshReused
 	}
 
-	consumed, err := readUInt64(res.Rows[0][0])
-	if err != nil {
-		return fmt.Errorf("oauth_state: parse consumed count: %w", err)
-	}
-	revoked, err := readUInt64(res.Rows[0][1])
-	if err != nil {
-		return fmt.Errorf("oauth_state: parse revoked count: %w", err)
-	}
-
-	if consumed > 0 || revoked > 0 {
-		if _, ierr := cli.ExecuteQuery(ctx, insertRevokedQuery, familyID, reason); ierr != nil {
-			return fmt.Errorf("oauth_state: insert revoked family: %w", ierr)
+	// 2. Atomic claim. KeeperMap strict-mode INSERT is linearized through
+	// Keeper Raft: exactly one of N concurrent redeemers wins, the rest
+	// see a duplicate-key exception. The winner returns nil; the losers
+	// fall into the reuse-detected branch below.
+	if _, ierr := cli.ExecuteQuery(ctx, insertConsumedQuery, jti, familyID); ierr != nil {
+		if !isKeeperMapDuplicateKeyError(ierr) {
+			return fmt.Errorf("oauth_state: insert consumed jti: %w", ierr)
+		}
+		// 3. Reuse detected. Record the family revocation. Idempotent
+		// across parallel losers (multiple INSERTs to revoked_families
+		// merge / TTL-expire). If the revoke INSERT itself fails we
+		// still return ErrRefreshReused — better to over-reject than
+		// silently mint a duplicate, and the family is logically
+		// revoked for the next refresh attempt either way (the
+		// duplicate-key error is the SECURITY signal; the revoke
+		// table is the audit trail).
+		if _, rerr := cli.ExecuteQuery(ctx, insertRevokedQuery, familyID, reason); rerr != nil {
+			log.Warn().
+				Err(rerr).
+				Str("family_id", familyID).
+				Msg("oauth_state: revoked-family insert failed (non-fatal — family is logically revoked anyway)")
 		}
 		return ErrRefreshReused
 	}
 
-	if _, ierr := cli.ExecuteQuery(ctx, insertConsumedQuery, jti, familyID); ierr != nil {
-		return fmt.Errorf("oauth_state: insert consumed jti: %w", ierr)
+	// Winner. Caller mints new tokens with the same family_id.
+	return nil
+}
+
+func (s *chStore) familyRevoked(ctx context.Context, cli CHClient, familyID string) (bool, error) {
+	res, err := cli.ExecuteQuery(ctx, selectRevokedQuery, familyID)
+	if err != nil {
+		return false, err
+	}
+	if res == nil || res.Count != 1 || len(res.Rows) != 1 || len(res.Rows[0]) < 1 {
+		return false, fmt.Errorf("oauth_state: unexpected revoked-select shape")
+	}
+	revoked, perr := readUInt64(res.Rows[0][0])
+	if perr != nil {
+		return false, fmt.Errorf("oauth_state: parse revoked count: %w", perr)
+	}
+	return revoked > 0, nil
+}
+
+// isKeeperMapDuplicateKeyError detects ClickHouse's strict-mode KeeperMap
+// duplicate-PRIMARY-KEY exception. The exact surfaced error message,
+// verified empirically against CH 26.1.6 stock running KeeperMap with
+// `keeper_map_strict_mode=1`:
+//
+//	Code: 999. DB::Exception: Coordination::Exception. Transaction failed
+//	(Node exists): Op #0, path: /altinity_mcp/keeper_map/.../data/<key>.
+//	(KEEPER_EXCEPTION)
+//
+// We match on `Transaction failed (Node exists)` — the most specific,
+// stable phrase across CH versions — and accept either case form since
+// some driver paths capitalise differently. Code 999 (KEEPER_EXCEPTION)
+// is checked separately as a backstop in case the message format drifts.
+//
+// Risk of over-matching: very low. `Transaction failed (Node exists)`
+// is the Keeper Raft phrase for "create-if-absent rejected because the
+// node exists" — for KeeperMap this only fires on PRIMARY KEY collision.
+// Other Keeper errors (timeout, leader-loss, etc.) produce different
+// messages.
+func isKeeperMapDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "Transaction failed (Node exists)") {
+		return true
+	}
+	// Lowercased fallback — defensive; not observed in 26.1.6 but cheap.
+	if strings.Contains(strings.ToLower(msg), "transaction failed (node exists)") {
+		return true
+	}
+	return false
+}
+
+func (s *chStore) Cleanup(ctx context.Context, retention time.Duration) error {
+	cli, err := s.newClient(ctx)
+	if err != nil {
+		return fmt.Errorf("oauth_state cleanup: open CH client: %w", err)
+	}
+	defer func() { _ = cli.Close() }()
+	cutoffSeconds := int64(retention.Seconds())
+	if cutoffSeconds <= 0 {
+		return fmt.Errorf("oauth_state cleanup: retention must be positive (got %v)", retention)
+	}
+	if _, err := cli.ExecuteQuery(ctx, deleteOldConsumedQuery, cutoffSeconds); err != nil {
+		return fmt.Errorf("oauth_state cleanup: ALTER DELETE: %w", err)
 	}
 	return nil
 }

--- a/pkg/oauth_state/store.go
+++ b/pkg/oauth_state/store.go
@@ -1,0 +1,180 @@
+// Package oauth_state implements server-side state for OAuth refresh-token
+// reuse detection (H-2 in the OAuth security review).
+//
+// On every gating-mode `grant_type=refresh_token` request, the handler:
+//
+//  1. Calls Store.CheckAndConsume with the presented refresh token's jti
+//     and family_id.
+//  2. If the jti was already in the consumed-jti table OR the family_id was
+//     already in the revoked-families table, the entire family is revoked
+//     and ErrRefreshReused is returned. The handler must reject the request.
+//  3. Otherwise, the jti is recorded as consumed and the handler mints a
+//     fresh access+refresh pair sharing the same family_id with a new jti.
+//
+// The implementation is intentionally minimal: two ClickHouse tables in the
+// `altinity` database, each Replicated|MergeTree with TTL 35 days. Operators
+// pre-create the schema (see docs/sql/oauth-state.sql) — the binary never
+// issues DDL.
+package oauth_state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/altinity/altinity-mcp/pkg/clickhouse"
+)
+
+// ErrRefreshReused signals that the presented refresh token's jti was
+// already consumed or its family was already revoked. The store has
+// recorded the family in oauth_refresh_revoked_families before returning
+// this error. Callers must reject the refresh with `invalid_grant`.
+var ErrRefreshReused = errors.New("oauth_state: refresh token reuse detected, family revoked")
+
+// Store handles OAuth refresh-token reuse detection.
+type Store interface {
+	// CheckAndConsume looks up the jti + family_id, marks the family
+	// revoked on a hit, or marks the jti consumed on a miss.
+	//
+	// `reason` is recorded in oauth_refresh_revoked_families for audit;
+	// suggested values: "reuse_detected", "manual_revoke".
+	//
+	// Returns ErrRefreshReused on reuse, nil on a fresh redemption,
+	// or a wrapped CH error on infrastructure failure (caller hard-fails).
+	CheckAndConsume(ctx context.Context, jti, familyID, reason string) error
+}
+
+// CHClient is the subset of *clickhouse.Client used by chStore. It exists
+// so tests can inject fakes without depending on the real driver.
+type CHClient interface {
+	ExecuteQuery(ctx context.Context, query string, args ...interface{}) (*clickhouse.QueryResult, error)
+	Close() error
+}
+
+// ClientFactory returns a fresh ClickHouse client per call. The store
+// closes the client after each CheckAndConsume.
+//
+// In production this is wired to ClickHouseJWEServer.GetClickHouseSystemClient
+// so state queries authorize as the pool user (mcp_service) and bypass the
+// cluster-secret + initial_user impersonation used for end-user-bound queries.
+type ClientFactory func(ctx context.Context) (CHClient, error)
+
+type chStore struct {
+	newClient ClientFactory
+}
+
+// NewClickHouseStore wires a Store to a ClickHouse connection factory.
+func NewClickHouseStore(newClient ClientFactory) Store {
+	return &chStore{newClient: newClient}
+}
+
+// Table names are hardcoded — operators created them via the documented DDL.
+const (
+	consumedJtisTable    = "altinity.oauth_refresh_consumed_jtis"
+	revokedFamiliesTable = "altinity.oauth_refresh_revoked_families"
+)
+
+// Combined existence check: one round trip yields both consumed-jti and
+// revoked-family counts. Subqueries each use the table's primary-key
+// index (ORDER BY jti / ORDER BY family_id), so each is a sparse-index
+// lookup, not a scan.
+const checkQuery = `
+SELECT
+    (SELECT count() FROM ` + consumedJtisTable + ` WHERE jti = ?) AS consumed,
+    (SELECT count() FROM ` + revokedFamiliesTable + ` WHERE family_id = ?) AS revoked
+`
+
+const insertConsumedQuery = `INSERT INTO ` + consumedJtisTable + ` (jti, family_id) VALUES (?, ?)`
+
+const insertRevokedQuery = `INSERT INTO ` + revokedFamiliesTable + ` (family_id, reason) VALUES (?, ?)`
+
+func (s *chStore) CheckAndConsume(ctx context.Context, jti, familyID, reason string) error {
+	if jti == "" || familyID == "" {
+		return fmt.Errorf("oauth_state: jti and family_id must both be non-empty")
+	}
+
+	cli, err := s.newClient(ctx)
+	if err != nil {
+		return fmt.Errorf("oauth_state: open CH client: %w", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	res, err := cli.ExecuteQuery(ctx, checkQuery, jti, familyID)
+	if err != nil {
+		return fmt.Errorf("oauth_state: select consumed/revoked: %w", err)
+	}
+	if res == nil || res.Count != 1 || len(res.Rows) != 1 || len(res.Rows[0]) < 2 {
+		return fmt.Errorf("oauth_state: unexpected select shape (count=%d rows=%d cols=%d)",
+			func() int {
+				if res == nil {
+					return 0
+				}
+				return res.Count
+			}(),
+			func() int {
+				if res == nil {
+					return 0
+				}
+				return len(res.Rows)
+			}(),
+			func() int {
+				if res == nil || len(res.Rows) == 0 {
+					return 0
+				}
+				return len(res.Rows[0])
+			}())
+	}
+
+	consumed, err := readUInt64(res.Rows[0][0])
+	if err != nil {
+		return fmt.Errorf("oauth_state: parse consumed count: %w", err)
+	}
+	revoked, err := readUInt64(res.Rows[0][1])
+	if err != nil {
+		return fmt.Errorf("oauth_state: parse revoked count: %w", err)
+	}
+
+	if consumed > 0 || revoked > 0 {
+		if _, ierr := cli.ExecuteQuery(ctx, insertRevokedQuery, familyID, reason); ierr != nil {
+			return fmt.Errorf("oauth_state: insert revoked family: %w", ierr)
+		}
+		return ErrRefreshReused
+	}
+
+	if _, ierr := cli.ExecuteQuery(ctx, insertConsumedQuery, jti, familyID); ierr != nil {
+		return fmt.Errorf("oauth_state: insert consumed jti: %w", ierr)
+	}
+	return nil
+}
+
+// readUInt64 normalizes count() return values across driver paths
+// (uint64/int64/*big.Int depending on protocol + version).
+func readUInt64(v interface{}) (uint64, error) {
+	switch t := v.(type) {
+	case uint64:
+		return t, nil
+	case int64:
+		if t < 0 {
+			return 0, fmt.Errorf("negative count %d", t)
+		}
+		return uint64(t), nil
+	case uint32:
+		return uint64(t), nil
+	case int:
+		if t < 0 {
+			return 0, fmt.Errorf("negative count %d", t)
+		}
+		return uint64(t), nil
+	case *big.Int:
+		if t == nil {
+			return 0, fmt.Errorf("nil *big.Int count")
+		}
+		if t.Sign() < 0 {
+			return 0, fmt.Errorf("negative count %s", t.String())
+		}
+		return t.Uint64(), nil
+	default:
+		return 0, fmt.Errorf("unexpected count type %T", v)
+	}
+}

--- a/pkg/oauth_state/store.go
+++ b/pkg/oauth_state/store.go
@@ -97,7 +97,13 @@ const (
 )
 
 // selectRevokedQuery returns 1 if the family is already revoked, 0 otherwise.
-// Cheap point-lookup (ORDER BY family_id) on a small ReplicatedMergeTree.
+// Both consumed_jtis and revoked_families are KeeperMap-backed; KeeperMap
+// reads are linearizable via Keeper Raft, so a write on pod A is visible
+// to pod B's next read regardless of which CH replica each pod talks to.
+// (Crucially this does NOT hold for ReplicatedMergeTree, whose async
+// replication leaves a window where pod B can fail to see pod A's recent
+// revoke. That window is what an attacker exploits to keep refreshing
+// the winning branch of a forked family.)
 const selectRevokedQuery = `SELECT count() FROM ` + revokedFamiliesTable + ` WHERE family_id = ?`
 
 // insertConsumedQuery atomically claims a jti slot in the KeeperMap-backed
@@ -113,12 +119,17 @@ const selectRevokedQuery = `SELECT count() FROM ` + revokedFamiliesTable + ` WHE
 const insertConsumedQuery = `INSERT INTO ` + consumedJtisTable + ` (jti, family_id) ` +
 	`SETTINGS keeper_map_strict_mode = 1 VALUES (?, ?)`
 
+// insertRevokedQuery records a family revocation. NOT strict mode: parallel
+// losers writing the same family_id are an idempotent overwrite (the second
+// loser's reason replaces the first, both succeed). KeeperMap silently
+// overwrites duplicate keys without strict mode set.
 const insertRevokedQuery = `INSERT INTO ` + revokedFamiliesTable + ` (family_id, reason) VALUES (?, ?)`
 
-// deleteOldConsumedQuery is the cleanup statement: KeeperMap doesn't support
-// CH-native TTL, so we run this on a goroutine ticker. Uses INTERVAL with a
-// bound seconds value (driver-side parametrization).
+// deleteOld* are the cleanup statements: KeeperMap doesn't support
+// CH-native TTL on either table, so the cleanup goroutine runs both on
+// the same ticker.
 const deleteOldConsumedQuery = `ALTER TABLE ` + consumedJtisTable + ` DELETE WHERE consumed_at < now() - toIntervalSecond(?)`
+const deleteOldRevokedQuery = `ALTER TABLE ` + revokedFamiliesTable + ` DELETE WHERE revoked_at < now() - toIntervalSecond(?)`
 
 func (s *chStore) CheckAndConsume(ctx context.Context, jti, familyID, reason string) error {
 	if jti == "" || familyID == "" {
@@ -131,10 +142,11 @@ func (s *chStore) CheckAndConsume(ctx context.Context, jti, familyID, reason str
 	}
 	defer func() { _ = cli.Close() }()
 
-	// 1. Cheap revocation check. If the family is already in
-	// revoked_families, fast-reject without burning a KeeperMap slot.
-	// Catches the case where a prior race-loser pod revoked the family
-	// and the legitimate owner is now refreshing.
+	// 1. Cheap revocation pre-check. KeeperMap point-lookup is linearizable
+	// (Keeper Raft); fast-rejects the legitimate owner refreshing after a
+	// prior race-loser pod revoked the family. Doesn't fully close the
+	// pre-check→claim TOCTOU window — see step 4 below for the post-claim
+	// re-check that does.
 	revoked, err := s.familyRevoked(ctx, cli, familyID)
 	if err != nil {
 		return fmt.Errorf("oauth_state: select revoked: %w", err)
@@ -143,28 +155,55 @@ func (s *chStore) CheckAndConsume(ctx context.Context, jti, familyID, reason str
 		return ErrRefreshReused
 	}
 
-	// 2. Atomic claim. KeeperMap strict-mode INSERT is linearized through
-	// Keeper Raft: exactly one of N concurrent redeemers wins, the rest
-	// see a duplicate-key exception. The winner returns nil; the losers
+	// 2. Atomic jti claim. KeeperMap strict-mode INSERT is serialised
+	// through Keeper Raft: exactly one of N concurrent redeemers wins,
+	// the rest see a duplicate-key exception. Winners proceed; losers
 	// fall into the reuse-detected branch below.
 	if _, ierr := cli.ExecuteQuery(ctx, insertConsumedQuery, jti, familyID); ierr != nil {
 		if !isKeeperMapDuplicateKeyError(ierr) {
 			return fmt.Errorf("oauth_state: insert consumed jti: %w", ierr)
 		}
-		// 3. Reuse detected. Record the family revocation. Idempotent
-		// across parallel losers (multiple INSERTs to revoked_families
-		// merge / TTL-expire). If the revoke INSERT itself fails we
-		// still return ErrRefreshReused — better to over-reject than
-		// silently mint a duplicate, and the family is logically
-		// revoked for the next refresh attempt either way (the
-		// duplicate-key error is the SECURITY signal; the revoke
-		// table is the audit trail).
+		// 3. Reuse detected. The revoke MUST persist before we tell the
+		// caller "family revoked" — if the row doesn't land, the
+		// winner's branch of the forked family stays alive on every
+		// MCP pod that subsequently reads revoked_families. The
+		// previous code logged WARN and returned ErrRefreshReused
+		// anyway; that left an attacker's chain extendable while the
+		// loser's request looked properly rejected. RFC 9700 requires
+		// family-wide revocation to be authoritative, not best-effort.
+		// On revoke INSERT failure we hard-fail the response (HTTP 500
+		// server_error) so the caller sees a security-relevant error
+		// and the operator pages.
 		if _, rerr := cli.ExecuteQuery(ctx, insertRevokedQuery, familyID, reason); rerr != nil {
-			log.Warn().
+			log.Error().
 				Err(rerr).
 				Str("family_id", familyID).
-				Msg("oauth_state: revoked-family insert failed (non-fatal — family is logically revoked anyway)")
+				Str("jti", jti).
+				Msg("oauth_state: SECURITY: reuse detected but revoke INSERT failed — family is NOT revoked")
+			return fmt.Errorf("oauth_state: revoke INSERT failed (security-critical): %w", rerr)
 		}
+		return ErrRefreshReused
+	}
+
+	// 4. Post-claim revocation re-check. Closes the TOCTOU window where
+	// another pod revoked the family between step 1 and step 2. Without
+	// this, a pod whose pre-check (step 1) raced ahead of a sibling pod's
+	// revoke (step 3 in that pod) can win step 2 and mint a token in an
+	// already-revoked family. KeeperMap reads are linearizable, so this
+	// re-check definitively reflects all revokes that committed before
+	// our claim landed.
+	revoked, err = s.familyRevoked(ctx, cli, familyID)
+	if err != nil {
+		// We claimed the jti slot but can't verify revocation state.
+		// Hard-fail; subsequent refresh of this token will hit the same
+		// checkpoint. The slot is "wasted" — fine, jtis are 128-bit random.
+		return fmt.Errorf("oauth_state: post-claim revoked re-check failed: %w", err)
+	}
+	if revoked {
+		// Family was revoked between our pre-check and our claim. Reject
+		// this redemption. The jti slot is consumed (good — prevents
+		// later replay of this same jti), and the family stays revoked
+		// (good — kills the chain).
 		return ErrRefreshReused
 	}
 
@@ -231,10 +270,20 @@ func (s *chStore) Cleanup(ctx context.Context, retention time.Duration) error {
 	if cutoffSeconds <= 0 {
 		return fmt.Errorf("oauth_state cleanup: retention must be positive (got %v)", retention)
 	}
+	// Both KeeperMap tables need application-side cleanup. Run them
+	// independently so a failure on one table doesn't mask a failure on
+	// the other; aggregate errors at the end.
+	var firstErr error
 	if _, err := cli.ExecuteQuery(ctx, deleteOldConsumedQuery, cutoffSeconds); err != nil {
-		return fmt.Errorf("oauth_state cleanup: ALTER DELETE: %w", err)
+		firstErr = fmt.Errorf("oauth_state cleanup: consumed_jtis ALTER DELETE: %w", err)
 	}
-	return nil
+	if _, err := cli.ExecuteQuery(ctx, deleteOldRevokedQuery, cutoffSeconds); err != nil {
+		if firstErr != nil {
+			return fmt.Errorf("%w; revoked_families ALTER DELETE: %v", firstErr, err)
+		}
+		return fmt.Errorf("oauth_state cleanup: revoked_families ALTER DELETE: %w", err)
+	}
+	return firstErr
 }
 
 // readUInt64 normalizes count() return values across driver paths

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/altinity/altinity-mcp/pkg/clickhouse"
 	"github.com/altinity/altinity-mcp/pkg/config"
+	"github.com/altinity/altinity-mcp/pkg/oauth_state"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rs/zerolog/log"
@@ -34,6 +35,11 @@ type ClickHouseJWEServer struct {
 	oidcConfigMu       sync.RWMutex
 	oidcConfigTime     time.Time
 	blockedClauses     map[string]bool
+
+	// refreshStateStore is non-nil only when oauth.refresh_revokes_tracking
+	// is enabled (H-2). Constructed in NewClickHouseMCPServer; consumed by
+	// the gating-mode refresh handler.
+	refreshStateStore oauth_state.Store
 }
 
 // ToolHandlerFunc is a function type for tool handlers
@@ -76,6 +82,14 @@ func NewClickHouseMCPServer(cfg config.Config, version string) *ClickHouseJWESer
 		blockedClauses: NormalizeBlockedClauses(cfg.Server.BlockedQueryClauses),
 	}
 
+	if cfg.Server.OAuth.IsGatingMode() && cfg.Server.OAuth.RefreshRevokesTracking {
+		chJweServer.refreshStateStore = oauth_state.NewClickHouseStore(
+			func(ctx context.Context) (oauth_state.CHClient, error) {
+				return chJweServer.GetClickHouseSystemClient(ctx)
+			},
+		)
+	}
+
 	// Register tools, resources, and prompts.
 	// Pass pointer to the server's Config so RegisterTools can store converted
 	// dynamic-tool rules back into Config.Server.DynamicTools for EnsureDynamicTools
@@ -93,6 +107,19 @@ func NewClickHouseMCPServer(cfg config.Config, version string) *ClickHouseJWESer
 		Msg("ClickHouse MCP server initialized with tools, resources, and prompts")
 
 	return chJweServer
+}
+
+// RefreshStateStore returns the H-2 reuse-detection store, or nil when
+// oauth.refresh_revokes_tracking is disabled.
+func (s *ClickHouseJWEServer) RefreshStateStore() oauth_state.Store {
+	return s.refreshStateStore
+}
+
+// SetRefreshStateStore overrides the H-2 store (test-only). Tests inject a
+// fake or in-memory implementation to exercise the refresh handler's
+// control flow without standing up a ClickHouse harness.
+func (s *ClickHouseJWEServer) SetRefreshStateStore(store oauth_state.Store) {
+	s.refreshStateStore = store
 }
 
 // AddTool registers a tool with the MCP server

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,29 @@ type ClickHouseJWEServer struct {
 	// is enabled (H-2). Constructed in NewClickHouseMCPServer; consumed by
 	// the gating-mode refresh handler.
 	refreshStateStore oauth_state.Store
+
+	// refreshStateCleanupCancel stops the H-2 cleanup goroutine. Non-nil
+	// only when the cleanup loop was started (i.e., refresh_revokes_tracking
+	// enabled at server-startup time). Tests call this to avoid leaked
+	// goroutines; production lets it run for the process lifetime.
+	refreshStateCleanupCancel func()
+}
+
+// serverCleanupRunner adapts *ClickHouseJWEServer to oauth_state.CleanupRunner.
+// It reads s.refreshStateStore on each tick so that SetRefreshStateStore
+// (test-only) takes effect on the cleanup loop too — without this, tests
+// that swap in a fake store would still see the production store fire
+// noisy WARN logs from a (typically broken) CH connection factory.
+type serverCleanupRunner struct {
+	s *ClickHouseJWEServer
+}
+
+func (r *serverCleanupRunner) Cleanup(ctx context.Context, retention time.Duration) error {
+	store := r.s.RefreshStateStore()
+	if store == nil {
+		return nil
+	}
+	return store.Cleanup(ctx, retention)
 }
 
 // ToolHandlerFunc is a function type for tool handlers
@@ -87,6 +110,18 @@ func NewClickHouseMCPServer(cfg config.Config, version string) *ClickHouseJWESer
 			func(ctx context.Context) (oauth_state.CHClient, error) {
 				return chJweServer.GetClickHouseSystemClient(ctx)
 			},
+		)
+		// H-2 cleanup loop. KeeperMap doesn't support CH-native TTL, so
+		// we run ALTER TABLE … DELETE on a goroutine ticker. The cancel
+		// function is stored so tests / shutdown paths can stop the loop;
+		// in production the loop runs for the server's lifetime and exits
+		// when the process does.
+		chJweServer.refreshStateCleanupCancel = oauth_state.StartCleanupLoop(
+			context.Background(),
+			&serverCleanupRunner{s: chJweServer},
+			oauth_state.DefaultCleanupInterval,
+			oauth_state.DefaultCleanupRetention,
+			0, // attemptTimeout: use default
 		)
 	}
 

--- a/pkg/server/server_client.go
+++ b/pkg/server/server_client.go
@@ -323,3 +323,31 @@ func (s *ClickHouseJWEServer) GetClickHouseClientWithOAuth(ctx context.Context, 
 
 	return client, nil
 }
+
+// GetClickHouseSystemClient creates a ClickHouse client that authorizes as the
+// configured pool user (config.ClickHouse.Username — typically `mcp_service`)
+// without applying the cluster-secret + initial_user impersonation that
+// GetClickHouseClientWithOAuth performs for end-user-bound queries.
+//
+// This is the connection used for server-internal state (e.g., the H-2
+// refresh-token reuse-detection tables in the `altinity` database). State
+// writes must NOT carry the requesting user's CH identity — they are
+// internal to MCP's OAuth bookkeeping.
+//
+// Constraints enforced by validateOAuthRuntimeConfig when H-2 is on:
+//   - cfg.ClickHouse.ReadOnly must be false
+//   - the CH-side user must lack READONLY=1 profile (operator's responsibility)
+func (s *ClickHouseJWEServer) GetClickHouseSystemClient(ctx context.Context) (*clickhouse.Client, error) {
+	chConfig := s.Config.ClickHouse
+	// Defensive: drop any tool-input settings that may have been injected
+	// for a parallel user-facing query path. State queries are server-
+	// internal; user-tunable settings have no business here.
+	chConfig.ExtraSettings = nil
+	// We deliberately do not consult oauthClaims, JWE claims, or
+	// tool-input settings — this is a system-level connection.
+	client, err := clickhouse.NewClient(ctx, chConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ClickHouse system client: %w", err)
+	}
+	return client, nil
+}

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -1,0 +1,128 @@
+# QA scripts — H-2 refresh-token reuse detection
+
+Regression coverage for the OAuth refresh-token atomicity property
+([#103](https://github.com/altinity/altinity-mcp/issues/103),
+[#106](https://github.com/altinity/altinity-mcp/pull/106)). These run
+against a **live deployment** (gating mode + `oauth.refresh_revokes_tracking: true`)
+and complement the unit test
+`TestOAuthRefreshReuseDetection_AtomicConcurrentClaim` in
+`cmd/altinity-mcp/oauth_server_test.go`.
+
+The unit test proves the handler's branching is correct against a
+synchronised in-memory fake. These scripts prove the property holds end
+-to-end through the live HTTP/JWE/Keeper stack — the surface where the
+SELECT-then-INSERT race the original H-2 design left open would actually
+manifest.
+
+## Prerequisites
+
+- `jq`, `openssl`, `python3`, `curl` (all on a stock macOS or any Linux)
+- A browser to complete the Auth0 login interactively (one click per run)
+- Network access to the target MCP `/oauth/{register,authorize,token}`
+  endpoints
+- Local port 8910 free (override with `PORT=…`)
+
+## When to run
+
+Run before merging any change that touches:
+
+- `pkg/oauth_state/store.go` — claim/revoke logic
+- `pkg/oauth_state/cleanup.go` — TTL replacement
+- `pkg/server/server_client.go:GetClickHouseSystemClient` — pool-user CH connection used by the store
+- `pkg/jwe_auth/jwe_auth.go` claims whitelist (specifically `family_id`/`jti`)
+- `cmd/altinity-mcp/oauth_server.go:mintGatingTokenResponse` — refresh-token claims
+- `cmd/altinity-mcp/oauth_server.go:handleOAuthTokenRefresh` — caller of CheckAndConsume
+- `docs/sql/oauth-state.sql` schema — KeeperMap table shape
+- CHI `<keeper_map_path_prefix>` config — operator-side enabling
+
+…against any environment running gating mode with H-2 enabled.
+
+## Scripts
+
+### `h2-replay-test.sh` — sequential reuse + family revocation
+
+Drives:
+
+1. DCR registration → ephemeral client_id
+2. `/oauth/authorize` → browser → Auth0 → `/oauth/callback` (captured by an
+   inline Python `http.server` on `localhost:8910`)
+3. `/oauth/token` `grant_type=authorization_code` → R0
+4. `/oauth/token` `grant_type=refresh_token` (R0) → expect **200 OK** → R1
+5. `/oauth/token` `grant_type=refresh_token` (**same R0**) → expect **400
+   `invalid_grant` "refresh token reuse detected"**
+6. (bonus) `/oauth/token` `grant_type=refresh_token` (R1) → expect **400
+   `invalid_grant`** even though R1 is a legitimate child of R0; family
+   revocation is family-wide per RFC 9700
+
+Override env: `MCP=https://otel-mcp.demo.altinity.cloud` (default), `PORT=8910`.
+
+State-table verification afterwards:
+
+```sql
+SELECT consumed_at, jti, family_id
+FROM   altinity.oauth_refresh_consumed_jtis
+ORDER BY consumed_at DESC LIMIT 3;
+-- expect: a row for R0's jti (claimed) + a row for R1's jti (claimed
+-- before the family was revoked)
+
+SELECT revoked_at, family_id, reason
+FROM   altinity.oauth_refresh_revoked_families
+ORDER BY revoked_at DESC LIMIT 3;
+-- expect: row with reason='reuse_detected', family_id matching the
+-- family from the consumed-jtis rows
+```
+
+### `h2-parallel-test.sh` — atomicity under concurrent replay
+
+The property the KeeperMap migration adds. Drives the same DCR + Auth0
+dance to obtain R0, then fires **N parallel redemptions** (default 50)
+of the same R0 via backgrounded `curl &` + `wait`. Asserts:
+
+- exactly **1 × 200 OK**
+- exactly **N − 1 × 400 `invalid_grant` "refresh token reuse detected"**
+- zero anomalies
+
+Non-zero exit on any deviation. Tweak concurrency via `N=…`.
+
+This is the test that the SELECT-then-INSERT design (PR #106 commit
+`0f3318d` before the atomicity fix) would FAIL — multiple redeemers
+racing through `count() = 0` would all win, family forks, no reuse
+detected. With KeeperMap strict mode, Keeper Raft serialises the
+concurrent INSERTs through the cluster leader; only one transaction
+wins, the rest receive `KEEPER_EXCEPTION: Transaction failed (Node
+exists)` (Code 999) and the handler maps that to the reuse-detected
+error response.
+
+State-table verification afterwards:
+
+```sql
+SELECT count() FROM altinity.oauth_refresh_consumed_jtis
+WHERE consumed_at > now() - 60;
+-- expect: 1 (only the winner's INSERT landed; the other 49 were rejected
+-- by KeeperMap before any row was created)
+
+SELECT family_id, reason FROM altinity.oauth_refresh_revoked_families
+WHERE revoked_at > now() - 60;
+-- expect: ≥1 row with reason='reuse_detected' (multiple losers may have
+-- written the same family_id; revoke is idempotent)
+```
+
+## Cleanup
+
+Both scripts use ephemeral DCR client_ids (one per run, JWE-stateless,
+expire on the OAuth signing-secret rotation). Nothing to clean up.
+
+The `consumed_jtis` rows from test runs decay automatically via the
+35-day cleanup goroutine in `pkg/oauth_state/cleanup.go`. The
+`revoked_families` rows decay via CH-native TTL.
+
+## Failure modes
+
+| Symptom                                          | Likely cause                                                                 |
+| ------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `localhost refused to connect` in browser        | python3 listener didn't bind — port 8910 in use; rerun with `PORT=…`          |
+| `no callback received within 5 min`              | browser tab was closed before submitting Auth0; rerun                         |
+| `token exchange failed: { … invalid_grant … }`   | auth code expired (60 s TTL); rerun the full flow                             |
+| `HTTP 500` `server_error` `refresh state unavailable` | CH unreachable, RBAC denied, or `keeper_map_path_prefix` missing on CHI — see [`docs/oauth-refresh-reuse-detection.md`](../../docs/oauth-refresh-reuse-detection.md) §Operator prerequisites |
+| Replay test sees 200 instead of 400              | The atomicity fix regressed; check `pkg/oauth_state/store.go:CheckAndConsume` for re-introduced check-then-act pattern; check `INSERT` statement still has `SETTINGS keeper_map_strict_mode = 1` |
+| Parallel test sees `success > 1`                 | Same as above, more dramatic. The KeeperMap claim is no longer atomic.       |

--- a/scripts/qa/h2-parallel-test.sh
+++ b/scripts/qa/h2-parallel-test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# H-2 atomicity test: drive N concurrent /oauth/token grant_type=refresh_token
+# requests with the SAME refresh JWE. KeeperMap strict-mode INSERT must
+# linearise the claim — exactly one wins, the rest get invalid_grant.
+#
+# Reuses h2-replay-test.sh's OAuth dance (DCR + Auth0 login + auth-code
+# exchange) up to obtaining R0, then fans out parallel redemptions.
+set -euo pipefail
+
+MCP="${MCP:-https://otel-mcp.demo.altinity.cloud}"
+PORT="${PORT:-8910}"
+N="${N:-50}"           # concurrent redeemers
+REDIR="http://localhost:${PORT}/cb"
+
+verifier=$(openssl rand -base64 32 | tr -d '=+/' | head -c 43)
+challenge=$(printf '%s' "$verifier" | openssl dgst -sha256 -binary | openssl base64 | tr -d '=' | tr '/+' '_-')
+state=$(openssl rand -hex 8)
+
+echo "[1/4] DCR + Auth0 dance (same as h2-replay-test.sh)"
+reg=$(curl -sS -X POST "$MCP/oauth/register" -H 'Content-Type: application/json' \
+  -d "$(printf '{"redirect_uris":["%s"],"token_endpoint_auth_method":"client_secret_post","grant_types":["authorization_code","refresh_token"]}' "$REDIR")")
+client_id=$(jq -r .client_id <<<"$reg")
+client_secret=$(jq -r .client_secret <<<"$reg")
+
+auth_url="$MCP/oauth/authorize?response_type=code&client_id=$(jq -rn --arg s "$client_id" '$s|@uri')&redirect_uri=$(jq -rn --arg s "$REDIR" '$s|@uri')&state=$state&code_challenge=$challenge&code_challenge_method=S256&scope=openid+email+profile"
+echo
+echo "    Open in browser: $auth_url"
+echo
+
+cb_file="/tmp/h2-cb-${PORT}.txt"
+rm -f "$cb_file"
+python3 - "$PORT" "$cb_file" <<'PY' &
+import http.server, socketserver, sys, urllib.parse, threading
+class H(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *a, **kw): pass
+    def do_GET(self):
+        with open(sys.argv[2], 'w') as f: f.write(urllib.parse.urlparse(self.path).query)
+        body = b"<html><body><h2>captured. close this tab.</h2></body></html>"
+        self.send_response(200); self.send_header('Content-Length', str(len(body))); self.end_headers()
+        self.wfile.write(body)
+        threading.Thread(target=self.server.shutdown, daemon=True).start()
+with socketserver.TCPServer(('127.0.0.1', int(sys.argv[1])), H) as srv:
+    srv.serve_forever()
+PY
+listener_pid=$!
+for _ in $(seq 1 300); do [ -s "$cb_file" ] && break; sleep 1; done
+wait "$listener_pid" 2>/dev/null || true
+[ -s "$cb_file" ] || { echo "no callback"; exit 1; }
+code=$(cat "$cb_file" | tr '&' '\n' | grep -E '^code=' | cut -d= -f2-)
+
+tok=$(curl -sS -X POST "$MCP/oauth/token" \
+  -d "grant_type=authorization_code" -d "code=$code" \
+  --data-urlencode "redirect_uri=$REDIR" \
+  -d "client_id=$client_id" -d "client_secret=$client_secret" \
+  --data-urlencode "code_verifier=$verifier")
+refresh=$(jq -r .refresh_token <<<"$tok")
+[ -n "$refresh" ] && [ "$refresh" != null ] || { echo "no refresh token: $tok"; exit 1; }
+echo "[2/4] got R0 (${#refresh} chars)"
+
+# Fan out N parallel redeems. Use & + wait, write each result to a numbered
+# file to avoid output interleaving. Curl gives us status code via -w.
+echo
+echo "[3/4] firing $N concurrent /oauth/token redemptions of the SAME R0"
+work=$(mktemp -d -t h2-parallel-XXXXX)
+trap 'rm -rf "$work"' EXIT
+
+for i in $(seq 1 "$N"); do
+    (curl -sS -o "$work/$i.body" -w "%{http_code}" -X POST "$MCP/oauth/token" \
+        -d "grant_type=refresh_token" \
+        -d "refresh_token=$refresh" \
+        -d "client_id=$client_id" \
+        -d "client_secret=$client_secret" > "$work/$i.code") &
+done
+wait
+
+success=0
+reuse=0
+other=0
+for i in $(seq 1 "$N"); do
+    code=$(cat "$work/$i.code")
+    case "$code" in
+        200) success=$((success+1)) ;;
+        400)
+            err=$(jq -r '.error // "?"' < "$work/$i.body" 2>/dev/null)
+            desc=$(jq -r '.error_description // "?"' < "$work/$i.body" 2>/dev/null)
+            if [ "$err" = "invalid_grant" ] && [[ "$desc" == *reuse* ]]; then
+                reuse=$((reuse+1))
+            else
+                other=$((other+1))
+                echo "    UNEXPECTED 400 from req $i: $err / $desc"
+            fi
+            ;;
+        *) other=$((other+1)); echo "    UNEXPECTED status $code from req $i: $(cat "$work/$i.body" | head -c 200)" ;;
+    esac
+done
+
+echo
+echo "[4/4] results:"
+echo "    200 OK (claimed):       $success"
+echo "    400 invalid_grant reuse: $reuse"
+echo "    other:                  $other"
+echo
+if [ "$success" -eq 1 ] && [ "$reuse" -eq $((N-1)) ] && [ "$other" -eq 0 ]; then
+    echo "✓ ATOMICITY CONFIRMED: exactly 1 winner, $((N-1)) reuse-detected, no anomalies"
+else
+    echo "✗ ANOMALY: expected exactly 1 winner + $((N-1)) reuse-detected"
+    exit 1
+fi
+
+echo
+echo "Verify state-table side effects:"
+echo "  echo \"SELECT count() FROM altinity.oauth_refresh_consumed_jtis WHERE consumed_at > now() - 60\" | ~/bin/cl otel"
+echo "  # expect: 1 (winning jti only — other 49 INSERTs were rejected by KeeperMap strict mode)"
+echo "  echo \"SELECT family_id, reason FROM altinity.oauth_refresh_revoked_families WHERE revoked_at > now() - 60\" | ~/bin/cl otel"
+echo "  # expect: 1 row, reason=reuse_detected (or possibly more rows if multiple losers wrote — that's idempotent)"

--- a/scripts/qa/h2-replay-test.sh
+++ b/scripts/qa/h2-replay-test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MCP="${MCP:-https://otel-mcp.demo.altinity.cloud}"
+PORT="${PORT:-8910}"
+REDIR="http://localhost:${PORT}/cb"
+
+# 1. PKCE verifier + challenge.
+verifier=$(openssl rand -base64 32 | tr -d '=+/' | head -c 43)
+challenge=$(printf '%s' "$verifier" | openssl dgst -sha256 -binary | openssl base64 | tr -d '=' | tr '/+' '_-')
+state=$(openssl rand -hex 8)
+
+# 2. DCR — register a confidential client.
+echo "[1/6] registering DCR client at $MCP/oauth/register"
+reg=$(curl -sS -X POST "$MCP/oauth/register" -H 'Content-Type: application/json' \
+  -d "$(printf '{"redirect_uris":["%s"],"token_endpoint_auth_method":"client_secret_post","grant_types":["authorization_code","refresh_token"]}' "$REDIR")")
+client_id=$(jq -r .client_id <<<"$reg")
+client_secret=$(jq -r .client_secret <<<"$reg")
+[ -n "$client_id" ] && [ "$client_id" != null ] || { echo "DCR failed: $reg"; exit 1; }
+echo "    client_id=${client_id:0:24}…"
+
+# 3. Build /oauth/authorize URL.
+auth_url="$MCP/oauth/authorize?response_type=code&client_id=$(jq -rn --arg s "$client_id" '$s|@uri')&redirect_uri=$(jq -rn --arg s "$REDIR" '$s|@uri')&state=$state&code_challenge=$challenge&code_challenge_method=S256&scope=openid+email+profile"
+echo
+echo "[2/6] open this URL in a browser, complete Auth0 login:"
+echo
+echo "    $auth_url"
+echo
+
+# 4. Listen on PORT for the callback. Inline Python — robust on macOS, doesn't
+#    depend on which nc flavor is installed. Writes the captured query string
+#    to /tmp/h2-cb-${PORT}.txt and exits cleanly with a 200 to the browser.
+cb_file="/tmp/h2-cb-${PORT}.txt"
+rm -f "$cb_file"
+echo "    waiting on http://localhost:$PORT/cb …"
+python3 - "$PORT" "$cb_file" <<'PY' &
+import http.server, socketserver, sys, urllib.parse, threading
+port = int(sys.argv[1])
+out  = sys.argv[2]
+class H(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *a, **kw): pass
+    def do_GET(self):
+        qs = urllib.parse.urlparse(self.path).query
+        with open(out, 'w') as f: f.write(qs)
+        body = b"<html><body><h2>code captured. you can close this tab.</h2></body></html>"
+        self.send_response(200)
+        self.send_header('Content-Type','text/html')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        threading.Thread(target=self.server.shutdown, daemon=True).start()
+with socketserver.TCPServer(('127.0.0.1', port), H) as srv:
+    srv.serve_forever()
+PY
+listener_pid=$!
+
+# Poll for the callback file (max 5 min).
+for _ in $(seq 1 300); do
+    [ -s "$cb_file" ] && break
+    sleep 1
+done
+wait "$listener_pid" 2>/dev/null || true
+[ -s "$cb_file" ] || { echo "no callback received within 5 min"; exit 1; }
+
+qs=$(cat "$cb_file")
+code=$(printf '%s' "$qs" | tr '&' '\n' | grep -E '^code=' | head -1 | cut -d= -f2-)
+[ -n "$code" ] || { echo "no code in callback: $qs"; exit 1; }
+echo "[3/6] captured code=${code:0:16}…"
+
+# 5. Exchange code → tokens.
+tok=$(curl -sS -X POST "$MCP/oauth/token" \
+  -d "grant_type=authorization_code" \
+  -d "code=$code" \
+  --data-urlencode "redirect_uri=$REDIR" \
+  -d "client_id=$client_id" \
+  -d "client_secret=$client_secret" \
+  --data-urlencode "code_verifier=$verifier")
+access=$(jq -r .access_token <<<"$tok")
+refresh=$(jq -r .refresh_token <<<"$tok")
+[ -n "$refresh" ] && [ "$refresh" != null ] || { echo "token exchange failed: $tok"; exit 1; }
+echo "[4/6] got access (${#access} chars) + refresh JWE R0 (${#refresh} chars)"
+
+# 6. First refresh — must succeed, mints R1.
+echo
+echo "[5/6] first refresh of R0 — expect 200 OK"
+r1_resp=$(curl -sS -w '\nHTTP %{http_code}' -X POST "$MCP/oauth/token" \
+  -d "grant_type=refresh_token" \
+  -d "refresh_token=$refresh" \
+  -d "client_id=$client_id" \
+  -d "client_secret=$client_secret")
+echo "$r1_resp" | sed -e 's/^/    /'
+
+# 7. Replay the SAME R0 — must fail and revoke family.
+echo
+echo "[6/6] REPLAY R0 — expect 400 invalid_grant 'reuse detected'"
+r2_resp=$(curl -sS -w '\nHTTP %{http_code}' -X POST "$MCP/oauth/token" \
+  -d "grant_type=refresh_token" \
+  -d "refresh_token=$refresh" \
+  -d "client_id=$client_id" \
+  -d "client_secret=$client_secret")
+echo "$r2_resp" | sed -e 's/^/    /'
+
+# 8. Optional: redeem R1 (legit child) — must ALSO fail (family revoked).
+r1=$(echo "$r1_resp" | head -1 | jq -r '.refresh_token // empty')
+if [ -n "$r1" ]; then
+    echo
+    echo "[bonus] redeem R1 (legit child) — expect 400 invalid_grant (family revoked)"
+    r3_resp=$(curl -sS -w '\nHTTP %{http_code}' -X POST "$MCP/oauth/token" \
+      -d "grant_type=refresh_token" \
+      -d "refresh_token=$r1" \
+      -d "client_id=$client_id" \
+      -d "client_secret=$client_secret")
+    echo "$r3_resp" | sed -e 's/^/    /'
+fi
+
+echo
+echo "Now check the state tables:"
+echo "  echo \"SELECT consumed_at, jti, family_id FROM altinity.oauth_refresh_consumed_jtis ORDER BY consumed_at DESC LIMIT 3\" | ~/bin/cl otel"
+echo "  echo \"SELECT revoked_at, family_id, reason FROM altinity.oauth_refresh_revoked_families ORDER BY revoked_at DESC LIMIT 3\" | ~/bin/cl otel"


### PR DESCRIPTION
> **v1 scope (2026-05-09): deferred, not dropped.** Product direction for v1 is **pure resource-only OAuth** — MCP advertises an external AS (Auth0 / Authentik / Keycloak) via RFC 9728 resource metadata; the AS owns DCR, `/authorize`, `/token`, refresh rotation, reuse detection, and revocation. claude.ai and ChatGPT DCR with the AS directly; MCP validates incoming AS-issued JWTs (signature + RFC 8707 audience byte-equality + expiry) and authorizes per-tool scopes.
>
> Under that v1 architecture, the custom token machinery this issue/PR introduces is unnecessary — the AS handles it. The work here becomes load-bearing again the moment MCP re-enters the AS business: to add a role-picker consent screen (the headline UX from #107 that Auth0's stock consent doesn't provide), to support deployments whose IdP lacks DCR (Google direct, basic-tier Auth0), or to layer MCP-side grant lifecycle management on top of the AS (#108).
>
> Treat this as **v2/v3 follow-up**: the design is sound, the security analysis stands, the implementation will be needed when v1's trade-offs (no consent-time role binding, AS-tier DCR requirement, AS-bound revocation latency) become product-relevant.
>
> ---
## Summary

Closes #103.

H-2 from the OAuth security review: **refresh-token reuse detection in gating mode**. Embeds `jti` + `family_id` into MCP-issued refresh JWEs and persists consumed jtis + revoked families in two ClickHouse tables. When a previously-redeemed jti is replayed, the entire token *family* is invalidated and the user re-authenticates.

This is the third of a 3-PR stack:

1. PR #104 — spec-compliance hardening + HKDF + C-1
2. PR #105 — H-1 require_email_verified gate
3. **This PR (PR-C)** — H-2 refresh-token reuse detection

> **Note on PR base:** Stacked on top of #105 (which is stacked on #104). Until both predecessors merge, the diff shown is against `feature/oauth-require-email-verified`. Once they land, GitHub auto-rebases this onto `main` and the diff narrows to the H-2 commit alone.

## Threat closed

Without H-2, a captured refresh JWE can be redeemed many times in parallel — each redemption mints a fresh access+refresh pair until the JWE's `exp` (default 30 days). An attacker who briefly captures a refresh token (leaked log, intermediate proxy, browser-extension compromise) gets a silent **30-day window** of access against the legitimate user's identity. The legitimate user has no signal.

With H-2, the moment the legitimate client refreshes after the attacker (or vice-versa), the loser's jti is in the consumed-set, the family is revoked, both parties are rejected on subsequent attempts, and the user re-auths once. The auth event is a clear signal.

OAuth 2.1 §4.13.2 and MCP authorization 2025-11-25 require this. RFC 6749 §10.4 frames the same requirement at SHOULD level for OAuth 2.0.

## Approach

| Claim       | Lifecycle                                                       |
| ----------- | --------------------------------------------------------------- |
| `jti`       | Fresh 16-byte random hex per issuance. **Different every refresh.** |
| `family_id` | Fresh 16-byte random hex at code→token exchange. **Stable across the entire rotation chain.** |

Two ClickHouse tables in a new `altinity` database:

| Table                                        | Purpose                                       | Lookup key  |
| -------------------------------------------- | --------------------------------------------- | ----------- |
| `altinity.oauth_refresh_consumed_jtis`       | Every redeemed refresh-token jti              | `jti`       |
| `altinity.oauth_refresh_revoked_families`    | Families flagged after reuse detection        | `family_id` |

Both `[Replicated]MergeTree` with `TTL ... + INTERVAL 35 DAY` for storage bound. Engine-agnostic Go code: SELECT and INSERT work the same on both.

Per refresh: 1 combined `SELECT count()` (two subqueries) + 1 `INSERT`. At realistic load (~hundreds of clients, refresh ~1×/h) ≈ 0.5 qps cluster-wide. Lookups happen only on `grant_type=refresh_token` — never on regular MCP requests (those validate access tokens locally via HMAC).

Out of scope (intentionally):

- **Forward mode.** Auth0 itself rotates and detects reuse upstream; our wrapper stays stateless to keep horizontal scaling cheap. Startup validation refuses `mode: forward` + the flag.
- **Single-node KV stores.** EmbeddedRocksDB doesn't replicate across MCP pods → reuse window opens between instances. KeeperMap couples OAuth correctness to Keeper ensemble health. Plain `[Replicated]MergeTree` is the right tool at this query volume.

## Operator prerequisite

Run `docs/sql/oauth-state.sql` (clustered or single-node flavor) as a CH admin user **before** flipping `oauth.refresh_revokes_tracking: true` in helm values. Creates the `altinity` database, both tables, and `GRANT INSERT, SELECT ON altinity.* TO mcp_service`.

When the flag is on:
- Startup refuses to boot if `mode: forward` or `clickhouse.read_only: true`
- The CH-side `mcp_service` user **cannot** have a `READONLY=1` profile (operator's responsibility — verify with `system.users` / `system.settings_profiles`)

Cluster name `all-replicated` is convention for a single logical shard spanning all replicas (sharding-compatible). Documented in `docs/oauth-refresh-reuse-detection.md`.

## Legacy-token policy

Refresh tokens issued before deploy lack `family_id`/`jti` → rejected with `invalid_grant` on first redemption. Clients re-authenticate once. Auto-promotion was rejected because it would let a captured pre-deploy token be replayed exactly once before tracking starts.

## Failure modes — hard fail with ERR

Every CH-state failure path returns HTTP 500 `server_error` and emits an ERR-level zerolog line. No silent fallthrough. Detailed table in `docs/oauth-refresh-reuse-detection.md` § Failure modes.

## Live deployment

Running on `otel-mcp.demo.altinity.cloud` since this commit landed (image `wip-oauth-h2-81b69b3`):
- ✅ Pod healthy, H-2 startup INF log fires
- ✅ State tables created with INSERT, SELECT grants on `mcp_service` (NOT readonly profile)
- ✅ Tool calls work end-to-end through claude.ai connector — `currentUser()` returns the impersonated email, confirming H-1 + H-2 + cluster_secret chain intact
- ✅ Legacy-token rejection observed (the documented "Anthropic Proxy: Invalid content from server" surfacing when pre-H-2 connectors first hit the new endpoint)
- ⏳ First `consumed_jti` row will land naturally when the otel connector's current 1h-TTL access token expires (token issued before H-2 deploy, exp ~17:28 UTC)

## Test plan

- [x] `pkg/oauth_state` unit tests cover happy-path / replay-revokes-family / legacy-token-rejected / state-unreachable / config-rejection (forward+flag, read_only+flag, empty database+flag)
- [x] In-memory fake `oauth_state.Store` exercises the refresh-handler control flow without standing up a CH harness
- [x] Live deployment on otel-mcp end-to-end smoke
- [ ] CI green on the full stacked diff
- [ ] Reviewer eyes on the consumed-jti / revoked-family TTL window (35 days vs 30-day refresh-token TTL — buffer for clock skew + replay windows)
- [ ] Negative replay test against `/oauth/token` with a captured refresh JWE (deferred — easy to drive once anyone wants to extract a refresh JWE from claude.ai's local cache)

## See also

- `docs/oauth-refresh-reuse-detection.md` — full design + threat model + DDL examples + grants + failure modes + rollback
- `docs/sql/oauth-state.sql` — operator DDL (clustered + single-node flavors)
- `/Users/Workspaces/acm/mcp/.wiki/mcp-oauth-debugging.md` § H-2 — operator wiki rollout checklist + per-deployment ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)