### PR TITLE
query: enforce result caps as server config instead of rewriting SQL

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -20,13 +20,31 @@ Two static tools are built into the server:
 
 `execute_query` accepts:
 
-- `query` (string, required) — the SQL to run.
-- `limit` (integer, optional) — caps returned rows.
+- `query` (string, required) — the SQL to run. Include `LIMIT N` in the SQL itself if you want a specific row cap; the server does not rewrite your query.
 - `settings` (object, optional) — ClickHouse query settings forwarded with the request.
 
 `write_query` accepts the same `query` and `settings` parameters and executes the statement as-is.
 
 **Handler mapping:** `name: execute_query` registers the `HandleReadOnlyQuery` function in `pkg/server/server.go`, which enforces the SELECT-only guard and then delegates to `HandleExecuteQuery`. `name: write_query` registers `HandleExecuteQuery` directly. These two names are the only valid values for static tool entries.
+
+### Server-enforced result caps
+
+Operators configure two DoS / context-window guardrails on `execute_query` and on read-mode dynamic tools (SELECT-like queries only — `write_query` and write-mode dynamic tools are unaffected):
+
+| Config key | Default | `0` means | Negative means |
+|------------|---------|-----------|----------------|
+| `clickhouse.max_result_rows` | 500 | use default | disable (defer to ClickHouse user profile) |
+| `clickhouse.max_result_bytes` | 50000 | use default | disable |
+
+The deprecated `clickhouse.limit` is kept as a silent alias for `clickhouse.max_result_rows` — when both are set, `max_result_rows` wins; the legacy key triggers a one-time deprecation warning at startup.
+
+Caps are enforced in two layers: ClickHouse session settings (`max_result_rows`, `max_result_bytes`, `result_overflow_mode='break'`) are pushed per-query so the engine stops early, and the MCP server itself stops appending rows once the configured cap is hit. The row cap is exact; the byte cap is approximate (cheap per-row sizing, not exact JSON byte counts).
+
+When a cap fires, the response carries:
+
+- A `truncated` object inside the JSON `QueryResult` with `reason` (`max_result_rows` or `max_result_bytes`), `limit`, `returned_rows`, and `returned_bytes_approx`.
+- For MCP tool responses: a second `text` content block explaining the truncation and recommending narrowing the query (tighter `WHERE`, server-side aggregation, key-range pagination, narrower `SELECT` list). The model should treat the data block as partial until the underlying query is narrowed.
+- For OpenAPI REST responses: an `X-MCP-Truncated: max_result_rows` (or `max_result_bytes`) HTTP header alongside the same body field.
 
 ---
 

--- a/pkg/clickhouse/client.go
+++ b/pkg/clickhouse/client.go
@@ -18,11 +18,29 @@ import (
 
 // QueryResult represents the result of a query execution
 type QueryResult struct {
-	Columns []string        `json:"columns"`
-	Types   []string        `json:"types"`
-	Rows    [][]interface{} `json:"rows"`
-	Count   int             `json:"count"`
-	Error   string          `json:"error,omitempty"`
+	Columns   []string        `json:"columns"`
+	Types     []string        `json:"types"`
+	Rows      [][]interface{} `json:"rows"`
+	Count     int             `json:"count"`
+	Error     string          `json:"error,omitempty"`
+	Truncated *TruncationInfo `json:"truncated,omitempty"`
+}
+
+// TruncationReason identifies which server-side cap fired.
+const (
+	TruncationReasonMaxResultRows  = "max_result_rows"
+	TruncationReasonMaxResultBytes = "max_result_bytes"
+)
+
+// TruncationInfo describes a result that was capped by MCP before being
+// returned to the caller. Surfaces in the JSON payload as `truncated` and is
+// also rendered as an extra MCP text-content block / X-MCP-Truncated header
+// at the handler layer so the model is told to narrow its query.
+type TruncationInfo struct {
+	Reason              string `json:"reason"`
+	Limit               int    `json:"limit"`
+	ReturnedRows        int    `json:"returned_rows"`
+	ReturnedBytesApprox int    `json:"returned_bytes_approx"`
 }
 
 // TableInfo represents information about a table
@@ -377,17 +395,58 @@ func scanRow(rows driver.Rows) ([]interface{}, error) {
 // ExecuteQuery executes a SQL query and returns results
 // For non-SELECT queries (DDL, DML) will return single row with `OK`
 func (c *Client) ExecuteQuery(ctx context.Context, query string, args ...interface{}) (*QueryResult, error) {
+	return c.executeWithCaps(ctx, query, 0, 0, args...)
+}
+
+// ExecuteCappedQuery executes a SELECT-like query subject to a server-controlled
+// row and/or byte cap. The caps are enforced in two layers:
+//  1. ClickHouse session settings (max_result_rows, max_result_bytes,
+//     result_overflow_mode='break') pushed via the per-query context — saves
+//     ClickHouse from computing rows that will be discarded; safe to no-op when
+//     the CH user profile forbids settings changes.
+//  2. A hard cap inside executeSelect's row-iteration loop — guarantees exact
+//     row counts (no block-granularity overshoot), bounds MCP-side memory, and
+//     works regardless of CH-side cooperation.
+//
+// On non-SELECT queries the caps are ignored and the call falls through to the
+// unsuppressed ExecuteQuery path. maxRows<=0 disables the row cap; maxBytes<=0
+// disables the byte cap.
+func (c *Client) ExecuteCappedQuery(ctx context.Context, query string, maxRows, maxBytes int, args ...interface{}) (*QueryResult, error) {
+	if maxRows <= 0 && maxBytes <= 0 {
+		return c.ExecuteQuery(ctx, query, args...)
+	}
+	if !IsSelectQuery(query) {
+		return c.ExecuteQuery(ctx, query, args...)
+	}
+	settings := clickhouse.Settings{
+		"result_overflow_mode": "break",
+	}
+	if maxRows > 0 {
+		// +1 so the engine returns at least one row past the cap when the
+		// underlying result is larger — Layer 2 uses that overshoot as the
+		// truncation signal.
+		settings["max_result_rows"] = uint64(maxRows + 1)
+	}
+	if maxBytes > 0 {
+		settings["max_result_bytes"] = uint64(maxBytes)
+	}
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(settings))
+	return c.executeWithCaps(ctx, query, maxRows, maxBytes, args...)
+}
+
+func (c *Client) executeWithCaps(ctx context.Context, query string, maxRows, maxBytes int, args ...interface{}) (*QueryResult, error) {
 	if c.config.ReadOnly && !IsSelectQuery(query) {
 		return nil, fmt.Errorf("query rejected: read-only mode allows only SELECT/WITH/SHOW/DESC/EXISTS/EXPLAIN statements")
 	}
 	if IsSelectQuery(query) {
-		return c.executeSelect(ctx, query, args...)
+		return c.executeSelect(ctx, query, maxRows, maxBytes, args...)
 	}
 	return c.executeNonSelect(ctx, query, args...)
 }
 
-// executeSelect executes a SELECT query
-func (c *Client) executeSelect(ctx context.Context, query string, args ...interface{}) (*QueryResult, error) {
+// executeSelect executes a SELECT query with optional row/byte caps.
+// maxRows<=0 disables the row cap; maxBytes<=0 disables the byte cap.
+func (c *Client) executeSelect(ctx context.Context, query string, maxRows, maxBytes int, args ...interface{}) (*QueryResult, error) {
 	result := &QueryResult{}
 
 	rows, err := c.conn.Query(ctx, query, args...)
@@ -415,13 +474,39 @@ func (c *Client) executeSelect(ctx context.Context, query string, args ...interf
 		result.Types[i] = ct.DatabaseTypeName()
 	}
 
-	// Fetch rows
+	// Fetch rows with optional caps.
+	bytesApprox := 0
 	for rows.Next() {
 		rowValues, err := scanRow(rows)
 		if err != nil {
 			return nil, err
 		}
+		// Row cap (Layer 2). The session-settings push asked CH for maxRows+1,
+		// so seeing a (maxRows+1)th row here means the underlying result was
+		// larger and we should truncate + flag.
+		if maxRows > 0 && len(result.Rows) >= maxRows {
+			result.Truncated = &TruncationInfo{
+				Reason:              TruncationReasonMaxResultRows,
+				Limit:               maxRows,
+				ReturnedRows:        len(result.Rows),
+				ReturnedBytesApprox: bytesApprox,
+			}
+			break
+		}
 		result.Rows = append(result.Rows, rowValues)
+		bytesApprox += approxRowBytes(rowValues)
+		// Byte cap (Layer 2). Stop after appending the row that first crosses
+		// the budget — one row of overshoot is the natural signal and keeps
+		// the code branch-free.
+		if maxBytes > 0 && bytesApprox > maxBytes {
+			result.Truncated = &TruncationInfo{
+				Reason:              TruncationReasonMaxResultBytes,
+				Limit:               maxBytes,
+				ReturnedRows:        len(result.Rows),
+				ReturnedBytesApprox: bytesApprox,
+			}
+			break
+		}
 	}
 
 	if err := rows.Err(); err != nil {
@@ -529,6 +614,30 @@ func truncateString(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// approxRowBytes returns a cheap, allocation-light estimate of the JSON-encoded
+// size of one result row. The exact serialized size doesn't matter for a DoS
+// guardrail — only the order of magnitude does, so we use len(fmt.Sprint(v))
+// per field plus a constant per-row overhead for column separators.
+func approxRowBytes(row []interface{}) int {
+	total := 2 // outer brackets per row in JSON
+	for _, v := range row {
+		if v == nil {
+			total += 4 // "null"
+			continue
+		}
+		switch s := v.(type) {
+		case string:
+			total += len(s) + 2 // quotes
+		case []byte:
+			total += len(s) + 2
+		default:
+			total += len(fmt.Sprint(v))
+		}
+		total++ // comma
+	}
+	return total
 }
 
 // convertToSerializable converts ClickHouse-specific types to JSON-serializable types

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,7 +40,11 @@ type ClickHouseConfig struct {
 	TLS              TLSConfig          `json:"tls" yaml:"tls"`
 	ReadOnly         bool               `json:"read_only" yaml:"read_only" flag:"read-only" env:"CLICKHOUSE_READ_ONLY" desc:"Connect to ClickHouse in read-only mode"`
 	MaxExecutionTime int                `json:"max_execution_time" yaml:"max_execution_time" flag:"clickhouse-max-execution-time" env:"CLICKHOUSE_MAX_EXECUTION_TIME" default:"600" desc:"ClickHouse max execution time in seconds"`
-	Limit            int                `json:"limit" yaml:"limit" flag:"clickhouse-limit" env:"CLICKHOUSE_LIMIT" desc:"Maximum limit for query results (0 means no limit)"`
+	// Limit is DEPRECATED; use MaxResultRows. Retained as a silent alias: when
+	// MaxResultRows is unset (0) and Limit > 0, EffectiveMaxResultRows() returns Limit.
+	Limit          int `json:"limit,omitempty" yaml:"limit,omitempty" flag:"clickhouse-limit" env:"CLICKHOUSE_LIMIT" desc:"DEPRECATED: alias for max_result_rows"`
+	MaxResultRows  int `json:"max_result_rows,omitempty" yaml:"max_result_rows,omitempty" flag:"clickhouse-max-result-rows" env:"CLICKHOUSE_MAX_RESULT_ROWS" desc:"Per-request row cap on SELECT-like queries (0=default 500, <0=disable and defer to ClickHouse user profile)"`
+	MaxResultBytes int `json:"max_result_bytes,omitempty" yaml:"max_result_bytes,omitempty" flag:"clickhouse-max-result-bytes" env:"CLICKHOUSE_MAX_RESULT_BYTES" desc:"Per-request approximate byte cap on result body (0=default 50000, <0=disable)"`
 	HttpHeaders      map[string]string  `json:"http_headers" yaml:"http_headers" flag:"clickhouse-http-headers" env:"CLICKHOUSE_HTTP_HEADERS" desc:"HTTP Headers for ClickHouse"`
 	ExtraSettings    map[string]string  `json:"extra_settings,omitempty" yaml:"extra_settings,omitempty" desc:"Per-request ClickHouse settings injected by tool_input_settings"`
 	// ClusterName + ClusterSecret enable interserver-secret authentication.
@@ -56,8 +60,42 @@ type ClickHouseConfig struct {
 	MaxQueryLength int `json:"max_query_length,omitempty" yaml:"max_query_length,omitempty" flag:"clickhouse-max-query-length" env:"CLICKHOUSE_MAX_QUERY_LENGTH" desc:"Max bytes of SQL query string accepted from clients (0=default 10MB, <0=disabled)"`
 }
 
-// defaultMaxQueryLength is the default cap applied when MaxQueryLength is 0.
-const defaultMaxQueryLength = 10 * 1024 * 1024 // 10 MiB
+// Defaults applied by the Effective* getters when the corresponding field is 0.
+// A negative value disables the cap entirely.
+const (
+	defaultMaxQueryLength = 10 * 1024 * 1024 // 10 MiB
+	defaultMaxResultRows  = 500
+	defaultMaxResultBytes = 50000
+)
+
+// EffectiveMaxResultRows returns the per-request row cap for SELECT-like queries.
+// Negative => disabled (defer to ClickHouse user profile); 0 => default 500;
+// >0 => exact cap. The deprecated Limit field is consulted as a silent alias
+// only when MaxResultRows is 0.
+func (c ClickHouseConfig) EffectiveMaxResultRows() int {
+	if c.MaxResultRows < 0 {
+		return 0
+	}
+	if c.MaxResultRows > 0 {
+		return c.MaxResultRows
+	}
+	if c.Limit > 0 {
+		return c.Limit
+	}
+	return defaultMaxResultRows
+}
+
+// EffectiveMaxResultBytes returns the approximate per-request response-body cap.
+// Negative => disabled; 0 => default 50000; >0 => exact cap.
+func (c ClickHouseConfig) EffectiveMaxResultBytes() int {
+	if c.MaxResultBytes < 0 {
+		return 0
+	}
+	if c.MaxResultBytes > 0 {
+		return c.MaxResultBytes
+	}
+	return defaultMaxResultBytes
+}
 
 // EffectiveMaxQueryLength returns the effective cap after applying defaults/disable semantics.
 // Returns 0 if the check is disabled.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -477,6 +477,29 @@ func TestConfigStructs(t *testing.T) {
 		require.Equal(t, "custom-value", cfg.HttpHeaders["X-Custom-Header"])
 	})
 
+	t.Run("effective_max_result_rows", func(t *testing.T) {
+		t.Parallel()
+		// Unset => default 500
+		require.Equal(t, 500, ClickHouseConfig{}.EffectiveMaxResultRows())
+		// Explicit positive value wins
+		require.Equal(t, 250, ClickHouseConfig{MaxResultRows: 250}.EffectiveMaxResultRows())
+		// Negative => disabled
+		require.Equal(t, 0, ClickHouseConfig{MaxResultRows: -1}.EffectiveMaxResultRows())
+		// Deprecated Limit is consulted only when MaxResultRows is 0
+		require.Equal(t, 1000, ClickHouseConfig{Limit: 1000}.EffectiveMaxResultRows())
+		// MaxResultRows beats Limit when both are set
+		require.Equal(t, 250, ClickHouseConfig{MaxResultRows: 250, Limit: 1000}.EffectiveMaxResultRows())
+		// Explicit-disable (negative) beats Limit too
+		require.Equal(t, 0, ClickHouseConfig{MaxResultRows: -1, Limit: 1000}.EffectiveMaxResultRows())
+	})
+
+	t.Run("effective_max_result_bytes", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, 50000, ClickHouseConfig{}.EffectiveMaxResultBytes())
+		require.Equal(t, 1000, ClickHouseConfig{MaxResultBytes: 1000}.EffectiveMaxResultBytes())
+		require.Equal(t, 0, ClickHouseConfig{MaxResultBytes: -1}.EffectiveMaxResultBytes())
+	})
+
 	t.Run("tls_config", func(t *testing.T) {
 		t.Parallel()
 		cfg := TLSConfig{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -85,10 +85,16 @@ func NewClickHouseMCPServer(cfg config.Config, version string) *ClickHouseJWESer
 	RegisterResources(chJweServer)
 	RegisterPrompts(chJweServer)
 
+	if cfg.ClickHouse.Limit > 0 && cfg.ClickHouse.MaxResultRows == 0 {
+		log.Warn().
+			Int("clickhouse.limit", cfg.ClickHouse.Limit).
+			Msg("clickhouse.limit is DEPRECATED; rename to clickhouse.max_result_rows. The legacy value is being used as a silent alias.")
+	}
 	log.Info().
 		Bool("jwe_enabled", cfg.Server.JWE.Enabled).
 		Bool("read_only", cfg.ClickHouse.ReadOnly).
-		Int("default_limit", cfg.ClickHouse.Limit).
+		Int("max_result_rows", cfg.ClickHouse.EffectiveMaxResultRows()).
+		Int("max_result_bytes", cfg.ClickHouse.EffectiveMaxResultBytes()).
 		Str("version", version).
 		Msg("ClickHouse MCP server initialized with tools, resources, and prompts")
 
@@ -287,11 +293,7 @@ func buildExecuteQueryTool(srvCfg *config.ServerConfig) *mcp.Tool {
 	properties := map[string]any{
 		"query": map[string]any{
 			"type":        "string",
-			"description": "Read-only SQL query (SELECT, WITH, SHOW, DESCRIBE, EXISTS, EXPLAIN).",
-		},
-		"limit": map[string]any{
-			"type":        "number",
-			"description": "Maximum number of rows to return (default: 100000)",
+			"description": "Read-only SQL query (SELECT, WITH, SHOW, DESCRIBE, EXISTS, EXPLAIN). Add LIMIT in the SQL itself to cap your own result size; the server also enforces operator-configured caps and signals truncation when they fire.",
 		},
 	}
 	if settingsSchema := buildToolInputSettingsSchema(srvCfg.ToolInputSettings); settingsSchema != nil {
@@ -416,6 +418,41 @@ func NewToolResultError(errMsg string) *mcp.CallToolResult {
 	}
 }
 
+// newQueryResultToolResult builds a CallToolResult for a query response,
+// appending a second text-content block when the result was truncated so the
+// model is told to narrow its query rather than acting on a partial answer.
+func newQueryResultToolResult(jsonData string, truncated *clickhouse.TruncationInfo) *mcp.CallToolResult {
+	content := []mcp.Content{&mcp.TextContent{Text: jsonData}}
+	if truncated != nil {
+		content = append(content, &mcp.TextContent{Text: truncationNotice(truncated)})
+	}
+	return &mcp.CallToolResult{Content: content}
+}
+
+// truncationNotice renders the human-readable warning that accompanies a
+// truncated result. Wording differs by cap so the model gets actionable advice.
+func truncationNotice(t *clickhouse.TruncationInfo) string {
+	switch t.Reason {
+	case clickhouse.TruncationReasonMaxResultRows:
+		return fmt.Sprintf(
+			"⚠️ Result truncated at the server-configured cap of %d rows (the underlying query returns more). "+
+				"This is a hard cap set by the operator, not a SQL LIMIT. "+
+				"To get a complete answer: narrow your WHERE clause, aggregate server-side, or paginate by a key range. "+
+				"Adding LIMIT N (N ≤ %d) to your SQL acknowledges the truncation but does not raise the cap.",
+			t.Limit, t.Limit,
+		)
+	case clickhouse.TruncationReasonMaxResultBytes:
+		return fmt.Sprintf(
+			"⚠️ Result truncated at the server-configured cap of ~%d bytes (returned ~%d bytes in %d rows). "+
+				"This is a hard cap set by the operator, not a SQL LIMIT. "+
+				"Wide rows hit this cap before the row cap — narrow your SELECT list (avoid SELECT *), aggregate server-side, or filter to a smaller subset.",
+			t.Limit, t.ReturnedBytesApprox, t.ReturnedRows,
+		)
+	default:
+		return fmt.Sprintf("⚠️ Result truncated (reason=%s, limit=%d). Narrow your query and retry.", t.Reason, t.Limit)
+	}
+}
+
 // HandleExecuteQuery implements the execute_query tool handler
 func HandleExecuteQuery(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// Get arguments from request
@@ -450,30 +487,7 @@ func HandleExecuteQuery(ctx context.Context, req *mcp.CallToolRequest) (*mcp.Cal
 		return NewToolResultError(fmt.Sprintf("Query rejected: %s clause is not allowed", clause)), nil
 	}
 
-	// Get optional limit parameter
-	var limit float64
-	hasLimit := false
-	if limitVal, exists := arguments["limit"]; exists {
-		if l, ok := limitVal.(float64); ok && l > 0 {
-			limit = l
-			hasLimit = true
-			// Check against configured max limit if one is set
-			if chJweServer.Config.ClickHouse.Limit > 0 && int(l) > chJweServer.Config.ClickHouse.Limit {
-				return NewToolResultError(fmt.Sprintf("Limit cannot exceed %d rows", chJweServer.Config.ClickHouse.Limit)), nil
-			}
-		}
-	}
-
-	log.Debug().
-		Str("query", query).
-		Float64("limit", limit).
-		Bool("has_limit", hasLimit).
-		Msg("Executing query")
-
-	// Add LIMIT clause for SELECT queries if limit is specified and not already present
-	if hasLimit && clickhouse.IsSelectQuery(query) && !hasLimitClause(query) {
-		query = fmt.Sprintf("%s LIMIT %.0f", strings.TrimSpace(query), limit)
-	}
+	log.Debug().Str("query", query).Msg("Executing query")
 
 	if len(chJweServer.Config.Server.ToolInputSettings) > 0 {
 		var errResult *mcp.CallToolResult
@@ -497,12 +511,13 @@ func HandleExecuteQuery(ctx context.Context, req *mcp.CallToolRequest) (*mcp.Cal
 		}
 	}()
 
-	result, err := chClient.ExecuteQuery(ctx, query)
+	maxRows := chJweServer.Config.ClickHouse.EffectiveMaxResultRows()
+	maxBytes := chJweServer.Config.ClickHouse.EffectiveMaxResultBytes()
+	result, err := chClient.ExecuteCappedQuery(ctx, query, maxRows, maxBytes)
 	if err != nil {
 		log.Error().
 			Err(err).
 			Str("query", query).
-			Float64("limit", limit).
 			Str("tool", "execute_query").
 			Msg("ClickHouse operation failed: query execution")
 		return NewToolResultError(fmt.Sprintf("Query execution failed: %s", truncateErrForClient(err))), nil
@@ -513,7 +528,7 @@ func HandleExecuteQuery(ctx context.Context, req *mcp.CallToolRequest) (*mcp.Cal
 		return NewToolResultError(fmt.Sprintf("Failed to marshal result: %v", err)), nil
 	}
 
-	return NewToolResultText(string(jsonData)), nil
+	return newQueryResultToolResult(string(jsonData), result.Truncated), nil
 }
 
 // GetClickHouseJWEServerFromContext extracts the ClickHouseJWEServer from context

--- a/pkg/server/server_dynamic_tools.go
+++ b/pkg/server/server_dynamic_tools.go
@@ -546,7 +546,9 @@ func makeDynamicToolHandler(meta dynamicToolMeta) ToolHandlerFunc {
 		}
 		query := fmt.Sprintf("SELECT * FROM %s.%s", meta.Database, fn)
 
-		result, err := chClient.ExecuteQuery(ctx, query)
+		maxRows := chJweServer.Config.ClickHouse.EffectiveMaxResultRows()
+		maxBytes := chJweServer.Config.ClickHouse.EffectiveMaxResultBytes()
+		result, err := chClient.ExecuteCappedQuery(ctx, query, maxRows, maxBytes)
 		if err != nil {
 			log.Error().Err(err).Str("tool", meta.ToolName).Str("query", query).Msg("dynamic_tools: query failed")
 			return NewToolResultError(fmt.Sprintf("Query execution failed: %v", truncateErrForClient(err))), nil
@@ -555,7 +557,7 @@ func makeDynamicToolHandler(meta dynamicToolMeta) ToolHandlerFunc {
 		if err != nil {
 			return NewToolResultError(err.Error()), nil
 		}
-		return NewToolResultText(string(jsonData)), nil
+		return newQueryResultToolResult(string(jsonData), result.Truncated), nil
 	}
 }
 

--- a/pkg/server/server_openapi.go
+++ b/pkg/server/server_openapi.go
@@ -6,10 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 
-	"github.com/altinity/altinity-mcp/pkg/clickhouse"
 	"github.com/altinity/altinity-mcp/pkg/jwe_auth"
 	"github.com/rs/zerolog/log"
 )
@@ -284,29 +282,6 @@ func (s *ClickHouseJWEServer) handleExecuteQueryOpenAPI(w http.ResponseWriter, r
 		return
 	}
 
-	limitStr := r.URL.Query().Get("limit")
-	var limit int
-	hasLimit := false
-	if limitStr != "" {
-		var err error
-		limit, err = strconv.Atoi(limitStr)
-		if err != nil || limit <= 0 {
-			http.Error(w, "Invalid limit parameter", http.StatusBadRequest)
-			return
-		}
-		hasLimit = true
-		// Check against configured max limit if one is set
-		if s.Config.ClickHouse.Limit > 0 && limit > s.Config.ClickHouse.Limit {
-			http.Error(w, fmt.Sprintf("Limit cannot exceed %d", s.Config.ClickHouse.Limit), http.StatusBadRequest)
-			return
-		}
-	}
-
-	// Add LIMIT clause for SELECT queries if limit is specified and not already present
-	if hasLimit && clickhouse.IsSelectQuery(query) && !hasLimitClause(query) {
-		query = fmt.Sprintf("%s LIMIT %d", strings.TrimSpace(query), limit)
-	}
-
 	ctx := r.Context()
 
 	// Extract tool input settings from query parameters
@@ -334,12 +309,17 @@ func (s *ClickHouseJWEServer) handleExecuteQueryOpenAPI(w http.ResponseWriter, r
 		}
 	}()
 
-	result, err := chClient.ExecuteQuery(ctx, query)
+	maxRows := s.Config.ClickHouse.EffectiveMaxResultRows()
+	maxBytes := s.Config.ClickHouse.EffectiveMaxResultBytes()
+	result, err := chClient.ExecuteCappedQuery(ctx, query, maxRows, maxBytes)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Query execution failed: %v", err), http.StatusInternalServerError)
 		return
 	}
 
+	if result.Truncated != nil {
+		w.Header().Set("X-MCP-Truncated", result.Truncated.Reason)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	if encodeErr := json.NewEncoder(w).Encode(result); encodeErr != nil {
 		log.Err(encodeErr).Msg("can't encode /openapi/execute_query result")
@@ -403,12 +383,17 @@ func (s *ClickHouseJWEServer) handleDynamicToolOpenAPI(w http.ResponseWriter, r 
 	}
 	query := fmt.Sprintf("SELECT * FROM %s.%s", meta.Database, fn)
 
-	result, err := chClient.ExecuteQuery(ctx, query)
+	maxRows := s.Config.ClickHouse.EffectiveMaxResultRows()
+	maxBytes := s.Config.ClickHouse.EffectiveMaxResultBytes()
+	result, err := chClient.ExecuteCappedQuery(ctx, query, maxRows, maxBytes)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Query execution failed: %v", truncateErrForClient(err)), http.StatusInternalServerError)
 		return
 	}
 
+	if result.Truncated != nil {
+		w.Header().Set("X-MCP-Truncated", result.Truncated.Reason)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	if encodeErr := json.NewEncoder(w).Encode(result); encodeErr != nil {
 		log.Err(encodeErr).Msg("can't encode dynamic tool result")

--- a/pkg/server/server_query.go
+++ b/pkg/server/server_query.go
@@ -3,16 +3,10 @@ package server
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 	"strings"
 
 	chparser "github.com/AfterShip/clickhouse-sql-parser/parser"
 )
-
-func hasLimitClause(query string) bool {
-	hasLimit, _ := regexp.MatchString(`(?im)limit\s+\d+`, query)
-	return hasLimit
-}
 
 // NormalizeBlockedClauses converts a list of clause names into a normalized
 // set (upper-cased). Returns nil for empty input.

--- a/pkg/server/server_query_test.go
+++ b/pkg/server/server_query_test.go
@@ -75,12 +75,12 @@ func TestHandleExecuteQuery(t *testing.T) {
 		require.GreaterOrEqual(t, qr.Count, 2)
 	})
 
-	t.Run("with_limit_parameter", func(t *testing.T) {
+	t.Run("with_sql_limit", func(t *testing.T) {
 		t.Parallel()
 		req := &mcp.CallToolRequest{
 			Params: &mcp.CallToolParamsRaw{
 				Name:      "execute_query",
-				Arguments: json.RawMessage(`{"query": "SELECT * FROM default.test", "limit": 1}`),
+				Arguments: json.RawMessage(`{"query": "SELECT * FROM default.test LIMIT 1"}`),
 			},
 		}
 
@@ -95,6 +95,7 @@ func TestHandleExecuteQuery(t *testing.T) {
 		var qr clickhouse.QueryResult
 		require.NoError(t, json.Unmarshal([]byte(textContent.Text), &qr))
 		require.Equal(t, 1, qr.Count)
+		require.Nil(t, qr.Truncated)
 	})
 
 	t.Run("missing_query_parameter", func(t *testing.T) {
@@ -138,14 +139,6 @@ func TestHelperFunctions(t *testing.T) {
 		require.True(t, clickhouse.IsSelectQuery("WITH cte AS (SELECT 1) SELECT * FROM cte"))
 		require.False(t, clickhouse.IsSelectQuery("INSERT INTO table VALUES (1)"))
 		require.False(t, clickhouse.IsSelectQuery("CREATE TABLE test (id Int)"))
-	})
-
-	t.Run("hasLimitClause", func(t *testing.T) {
-		t.Parallel()
-		require.True(t, hasLimitClause("SELECT * FROM table LIMIT 100"))
-		require.True(t, hasLimitClause("select * from table limit 50"))
-		require.False(t, hasLimitClause("SELECT * FROM table"))
-		require.False(t, hasLimitClause("SELECT * FROM table ORDER BY id"))
 	})
 
 	t.Run("snakeCase", func(t *testing.T) {
@@ -224,21 +217,19 @@ func TestHandleExecuteQuery_EmptyQuery(t *testing.T) {
 	require.True(t, result.IsError)
 }
 
-// TestHandleExecuteQuery_ExceedsMaxLimit tests limit exceeding config max
-func TestHandleExecuteQuery_ExceedsMaxLimit(t *testing.T) {
+// TestHandleExecuteQuery_RowCapTruncates verifies the operator-configured row
+// cap fires for an unbounded SELECT, returns exactly maxRows rows, and
+// surfaces a second text-content block alerting the model.
+func TestHandleExecuteQuery_RowCapTruncates(t *testing.T) {
 	t.Parallel()
 	chConfig := setupEmbeddedClickHouse(t)
 
+	cfg := *chConfig
+	cfg.MaxResultRows = 1
+
 	srv := NewClickHouseMCPServer(config.Config{
-		ClickHouse: config.ClickHouseConfig{
-			Host:     chConfig.Host,
-			Port:     chConfig.Port,
-			Database: chConfig.Database,
-			Username: chConfig.Username,
-			Protocol: chConfig.Protocol,
-			Limit:    10,
-		},
-		Server: config.ServerConfig{JWE: config.JWEConfig{Enabled: false}},
+		ClickHouse: cfg,
+		Server:     config.ServerConfig{JWE: config.JWEConfig{Enabled: false}},
 	}, "test")
 
 	ctx := context.WithValue(context.Background(), CHJWEServerKey, srv)
@@ -246,19 +237,33 @@ func TestHandleExecuteQuery_ExceedsMaxLimit(t *testing.T) {
 	req := &mcp.CallToolRequest{
 		Params: &mcp.CallToolParamsRaw{
 			Name:      "execute_query",
-			Arguments: json.RawMessage(`{"query": "SELECT * FROM default.test", "limit": 100}`),
+			Arguments: json.RawMessage(`{"query": "SELECT * FROM default.test"}`),
 		},
 	}
 
 	result, err := HandleExecuteQuery(ctx, req)
 	require.NoError(t, err)
-	require.True(t, result.IsError)
-	textContent, ok := result.Content[0].(*mcp.TextContent)
+	require.False(t, result.IsError)
+	require.Len(t, result.Content, 2, "expected data block + truncation notice")
+
+	dataBlock, ok := result.Content[0].(*mcp.TextContent)
 	require.True(t, ok)
-	require.Contains(t, textContent.Text, "Limit cannot exceed 10")
+	var qr clickhouse.QueryResult
+	require.NoError(t, json.Unmarshal([]byte(dataBlock.Text), &qr))
+	require.Equal(t, 1, qr.Count)
+	require.NotNil(t, qr.Truncated)
+	require.Equal(t, clickhouse.TruncationReasonMaxResultRows, qr.Truncated.Reason)
+	require.Equal(t, 1, qr.Truncated.Limit)
+
+	notice, ok := result.Content[1].(*mcp.TextContent)
+	require.True(t, ok)
+	require.Contains(t, notice.Text, "truncated")
+	require.Contains(t, notice.Text, "1 rows")
 }
 
-// TestHandleExecuteQuery_WithQueryWithExistingLimit tests query already having limit
+// TestHandleExecuteQuery_WithQueryWithExistingLimit verifies that a SELECT with
+// its own LIMIT round-trips cleanly. With the limit argument removed from the
+// tool schema, this just exercises the standard SELECT path.
 func TestHandleExecuteQuery_WithQueryWithExistingLimit(t *testing.T) {
 	t.Parallel()
 	chConfig := setupEmbeddedClickHouse(t)
@@ -273,7 +278,7 @@ func TestHandleExecuteQuery_WithQueryWithExistingLimit(t *testing.T) {
 	req := &mcp.CallToolRequest{
 		Params: &mcp.CallToolParamsRaw{
 			Name:      "execute_query",
-			Arguments: json.RawMessage(`{"query": "SELECT * FROM default.test LIMIT 5", "limit": 10}`),
+			Arguments: json.RawMessage(`{"query": "SELECT * FROM default.test LIMIT 5"}`),
 		},
 	}
 
@@ -585,30 +590,32 @@ func TestHandleExecuteQueryE2E(t *testing.T) {
 		require.True(t, result.IsError)
 	})
 
-	t.Run("with_limit", func(t *testing.T) {
-		req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "execute_query", Arguments: json.RawMessage(`{"query":"SELECT * FROM default.test","limit":1}`)}}
+	t.Run("with_sql_limit", func(t *testing.T) {
+		req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "execute_query", Arguments: json.RawMessage(`{"query":"SELECT * FROM default.test LIMIT 1"}`)}}
 		result, err := HandleExecuteQuery(ctx, req)
 		require.NoError(t, err)
 		require.False(t, result.IsError)
 	})
 
-	t.Run("limit_exceeds_max", func(t *testing.T) {
+	t.Run("server_row_cap_truncates", func(t *testing.T) {
+		cfg := *chConfig
+		cfg.MaxResultRows = 1
 		srvLimited := NewClickHouseMCPServer(config.Config{
-			ClickHouse: config.ClickHouseConfig{
-				Host:     chConfig.Host,
-				Port:     chConfig.Port,
-				Database: chConfig.Database,
-				Username: chConfig.Username,
-				Protocol: chConfig.Protocol,
-				Limit:    10,
-			},
-			Server: config.ServerConfig{JWE: config.JWEConfig{Enabled: false}},
+			ClickHouse: cfg,
+			Server:     config.ServerConfig{JWE: config.JWEConfig{Enabled: false}},
 		}, "test")
 		ctxLimited := context.WithValue(context.Background(), CHJWEServerKey, srvLimited)
-		req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "execute_query", Arguments: json.RawMessage(`{"query":"SELECT * FROM default.test","limit":100}`)}}
+		req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "execute_query", Arguments: json.RawMessage(`{"query":"SELECT * FROM default.test"}`)}}
 		result, err := HandleExecuteQuery(ctxLimited, req)
 		require.NoError(t, err)
-		require.True(t, result.IsError)
+		require.False(t, result.IsError)
+		require.Len(t, result.Content, 2, "expected truncation notice as second content block")
+		data, ok := result.Content[0].(*mcp.TextContent)
+		require.True(t, ok)
+		var qr clickhouse.QueryResult
+		require.NoError(t, json.Unmarshal([]byte(data.Text), &qr))
+		require.NotNil(t, qr.Truncated)
+		require.Equal(t, clickhouse.TruncationReasonMaxResultRows, qr.Truncated.Reason)
 	})
 
 	t.Run("no_server_in_context", func(t *testing.T) {
@@ -617,4 +624,116 @@ func TestHandleExecuteQueryE2E(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "can't get JWEServer from context")
 	})
+}
+
+// TestHandleExecuteQuery_IntrospectionWithCaps regression-tests issue #124: with
+// row/byte caps configured, DESCRIBE / SHOW CREATE / EXISTS must round-trip
+// without syntax errors (the old code appended LIMIT to non-SELECT row-returning
+// statements and ClickHouse rejected them).
+func TestHandleExecuteQuery_IntrospectionWithCaps(t *testing.T) {
+	t.Parallel()
+	chConfig := setupEmbeddedClickHouse(t)
+	cfg := *chConfig
+	cfg.MaxResultRows = 5
+	cfg.MaxResultBytes = 1000
+
+	srv := NewClickHouseMCPServer(config.Config{
+		ClickHouse: cfg,
+		Server:     config.ServerConfig{JWE: config.JWEConfig{Enabled: false}},
+	}, "test")
+	ctx := context.WithValue(context.Background(), CHJWEServerKey, srv)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"describe", "DESCRIBE default.test"},
+		{"desc_alias", "DESC default.test"},
+		{"show_create", "SHOW CREATE TABLE default.test"},
+		{"exists", "EXISTS TABLE default.test"},
+		{"explain_select", "EXPLAIN SELECT * FROM default.test"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+				Name:      "execute_query",
+				Arguments: json.RawMessage(`{"query":"` + tc.query + `"}`),
+			}}
+			result, err := HandleExecuteQuery(ctx, req)
+			require.NoError(t, err)
+			require.False(t, result.IsError, "query %q rejected: %v", tc.query, result.Content)
+		})
+	}
+}
+
+// TestHandleExecuteQuery_ByteCapFires verifies the byte cap trips on a wide-row
+// SELECT even before the row cap would have, and the model gets a notice that
+// explicitly mentions wide rows / SELECT list narrowing.
+func TestHandleExecuteQuery_ByteCapFires(t *testing.T) {
+	t.Parallel()
+	chConfig := setupEmbeddedClickHouse(t)
+	cfg := *chConfig
+	cfg.MaxResultRows = 500
+	cfg.MaxResultBytes = 64
+
+	srv := NewClickHouseMCPServer(config.Config{
+		ClickHouse: cfg,
+		Server:     config.ServerConfig{JWE: config.JWEConfig{Enabled: false}},
+	}, "test")
+	ctx := context.WithValue(context.Background(), CHJWEServerKey, srv)
+
+	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+		Name:      "execute_query",
+		Arguments: json.RawMessage(`{"query":"SELECT number, repeat('x', 100) AS pad FROM system.numbers LIMIT 100"}`),
+	}}
+	result, err := HandleExecuteQuery(ctx, req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Len(t, result.Content, 2)
+
+	data, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var qr clickhouse.QueryResult
+	require.NoError(t, json.Unmarshal([]byte(data.Text), &qr))
+	require.NotNil(t, qr.Truncated)
+	require.Equal(t, clickhouse.TruncationReasonMaxResultBytes, qr.Truncated.Reason)
+	require.Equal(t, 64, qr.Truncated.Limit)
+
+	notice, ok := result.Content[1].(*mcp.TextContent)
+	require.True(t, ok)
+	require.Contains(t, notice.Text, "bytes")
+	require.Contains(t, notice.Text, "SELECT *")
+}
+
+// TestHandleExecuteQuery_CapsDisabled verifies that MaxResultRows<0 and
+// MaxResultBytes<0 disable both layers — unbounded SELECTs return all rows,
+// no truncation flag, no notice block.
+func TestHandleExecuteQuery_CapsDisabled(t *testing.T) {
+	t.Parallel()
+	chConfig := setupEmbeddedClickHouse(t)
+	cfg := *chConfig
+	cfg.MaxResultRows = -1
+	cfg.MaxResultBytes = -1
+
+	srv := NewClickHouseMCPServer(config.Config{
+		ClickHouse: cfg,
+		Server:     config.ServerConfig{JWE: config.JWEConfig{Enabled: false}},
+	}, "test")
+	ctx := context.WithValue(context.Background(), CHJWEServerKey, srv)
+
+	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+		Name:      "execute_query",
+		Arguments: json.RawMessage(`{"query":"SELECT number FROM system.numbers LIMIT 1000"}`),
+	}}
+	result, err := HandleExecuteQuery(ctx, req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Len(t, result.Content, 1, "no truncation notice expected")
+
+	data, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var qr clickhouse.QueryResult
+	require.NoError(t, json.Unmarshal([]byte(data.Text), &qr))
+	require.Equal(t, 1000, qr.Count)
+	require.Nil(t, qr.Truncated)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -92,14 +92,14 @@ func TestOpenAPIHandlers(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code)
 	})
 
-	t.Run("execute_query_with_limit", func(t *testing.T) {
+	t.Run("execute_query_with_sql_limit", func(t *testing.T) {
 		t.Parallel()
 		srv := NewClickHouseMCPServer(config.Config{
 			ClickHouse: *chConfig,
 			Server:     config.ServerConfig{JWE: config.JWEConfig{Enabled: false}},
 		}, "test")
 
-		req := httptest.NewRequest(http.MethodGet, "/openapi/execute_query?query=SELECT%20*%20FROM%20default.test&limit=1", nil)
+		req := httptest.NewRequest(http.MethodGet, "/openapi/execute_query?query=SELECT+*+FROM+default.test+LIMIT+1", nil)
 		req = req.WithContext(context.WithValue(req.Context(), CHJWEServerKey, srv))
 
 		rr := httptest.NewRecorder()
@@ -109,6 +109,7 @@ func TestOpenAPIHandlers(t *testing.T) {
 		var qr clickhouse.QueryResult
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &qr))
 		require.Equal(t, 1, qr.Count)
+		require.Empty(t, rr.Header().Get("X-MCP-Truncated"))
 	})
 
 	t.Run("execute_query_missing_param", func(t *testing.T) {
@@ -729,75 +730,34 @@ func TestHandleExecuteQueryOpenAPI_MethodNotAllowed(t *testing.T) {
 	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
 }
 
-// TestHandleExecuteQueryOpenAPI_InvalidLimit tests invalid limit parameter
-func TestHandleExecuteQueryOpenAPI_InvalidLimit(t *testing.T) {
+// TestHandleExecuteQueryOpenAPI_RowCapTruncates verifies the operator-configured
+// row cap fires on an unbounded SELECT served via OpenAPI, returns 200, sets
+// X-MCP-Truncated, and embeds the truncation info in the JSON body.
+func TestHandleExecuteQueryOpenAPI_RowCapTruncates(t *testing.T) {
 	t.Parallel()
 	chConfig := setupEmbeddedClickHouse(t)
+	cfg := *chConfig
+	cfg.MaxResultRows = 1
 
 	srv := NewClickHouseMCPServer(config.Config{
-		ClickHouse: *chConfig,
+		ClickHouse: cfg,
 		Server:     config.ServerConfig{JWE: config.JWEConfig{Enabled: false}},
 	}, "test")
 
-	t.Run("non_numeric_limit", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest(http.MethodGet, "/openapi/execute_query?query=SELECT%201&limit=abc", nil)
-		req = req.WithContext(context.WithValue(req.Context(), CHJWEServerKey, srv))
-
-		rr := httptest.NewRecorder()
-		srv.handleExecuteQueryOpenAPI(rr, req)
-
-		require.Equal(t, http.StatusBadRequest, rr.Code)
-	})
-
-	t.Run("zero_limit", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest(http.MethodGet, "/openapi/execute_query?query=SELECT%201&limit=0", nil)
-		req = req.WithContext(context.WithValue(req.Context(), CHJWEServerKey, srv))
-
-		rr := httptest.NewRecorder()
-		srv.handleExecuteQueryOpenAPI(rr, req)
-
-		require.Equal(t, http.StatusBadRequest, rr.Code)
-	})
-
-	t.Run("negative_limit", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest(http.MethodGet, "/openapi/execute_query?query=SELECT%201&limit=-1", nil)
-		req = req.WithContext(context.WithValue(req.Context(), CHJWEServerKey, srv))
-
-		rr := httptest.NewRecorder()
-		srv.handleExecuteQueryOpenAPI(rr, req)
-
-		require.Equal(t, http.StatusBadRequest, rr.Code)
-	})
-}
-
-// TestHandleExecuteQueryOpenAPI_ExceedsMaxLimit tests limit exceeding max
-func TestHandleExecuteQueryOpenAPI_ExceedsMaxLimit(t *testing.T) {
-	t.Parallel()
-	chConfig := setupEmbeddedClickHouse(t)
-
-	srv := NewClickHouseMCPServer(config.Config{
-		ClickHouse: config.ClickHouseConfig{
-			Host:     chConfig.Host,
-			Port:     chConfig.Port,
-			Database: chConfig.Database,
-			Username: chConfig.Username,
-			Protocol: chConfig.Protocol,
-			Limit:    10,
-		},
-		Server: config.ServerConfig{JWE: config.JWEConfig{Enabled: false}},
-	}, "test")
-
-	req := httptest.NewRequest(http.MethodGet, "/openapi/execute_query?query=SELECT%201&limit=100", nil)
+	req := httptest.NewRequest(http.MethodGet, "/openapi/execute_query?query=SELECT+*+FROM+default.test", nil)
 	req = req.WithContext(context.WithValue(req.Context(), CHJWEServerKey, srv))
 
 	rr := httptest.NewRecorder()
 	srv.handleExecuteQueryOpenAPI(rr, req)
 
-	require.Equal(t, http.StatusBadRequest, rr.Code)
-	require.Contains(t, rr.Body.String(), "Limit cannot exceed 10")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, clickhouse.TruncationReasonMaxResultRows, rr.Header().Get("X-MCP-Truncated"))
+
+	var qr clickhouse.QueryResult
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &qr))
+	require.Equal(t, 1, qr.Count)
+	require.NotNil(t, qr.Truncated)
+	require.Equal(t, 1, qr.Truncated.Limit)
 }
 
 // TestHandleDynamicToolOpenAPI_MethodNotAllowed tests method validation


### PR DESCRIPTION
Closes #124.

## Summary

- Drop the `limit` argument from `execute_query` and the OpenAPI `?limit=` query parameter — the rewrite-the-SQL approach broke `DESCRIBE`/`SHOW`/`EXISTS` and solved the wrong problem.
- Add two operator-controlled config keys: `clickhouse.max_result_rows` (default 500) and `clickhouse.max_result_bytes` (default 50000). `0` = use default, negative = disable (defer to ClickHouse user profile).
- Keep `clickhouse.limit` as a silent alias for `max_result_rows`; log a one-time deprecation warning at startup when it's set.
- Apply caps uniformly to `execute_query` (MCP + OpenAPI) and read-mode dynamic tools (MCP + OpenAPI). `write_query` and write-mode dynamic tools are unaffected. Discovery clients (`getDiscoveryClient`) keep calling plain `ExecuteQuery`, so internal introspection queries stay uncapped.
- Two-layer enforcement: ClickHouse session settings (`max_result_rows = configured+1`, `max_result_bytes`, `result_overflow_mode='break'`) pushed per-query via `clickhouse.Context(WithSettings)` so the engine stops early; plus a hard cap inside `executeSelect`'s `rows.Next()` loop for exact row counts, MCP-side OOM protection, and resilience to `readonly=1` CH user profiles.
- Truncation is surfaced explicitly so the model knows its view is partial:
  - `QueryResult.Truncated` JSON field with `reason` / `limit` / `returned_rows` / `returned_bytes_approx`.
  - MCP tool responses append a second `TextContent` block recommending narrowing the query (tighter `WHERE`, aggregation, key-range pagination, narrower `SELECT` list — **not** "smaller LIMIT", since a model that wanted 5000 rows and got 500 wants *more*).
  - OpenAPI responses set `X-MCP-Truncated: max_result_rows` (or `max_result_bytes`).
- Updated `docs/tools.md` with the new keys, semantics, and signaling contract.

## Test plan

- [x] `go test -count=1 ./...` passes against embedded ClickHouse — all packages green.
- [x] Regression coverage for issue #124: `DESCRIBE` / `DESC` / `SHOW CREATE TABLE` / `EXISTS TABLE` / `EXPLAIN SELECT` round-trip with caps configured (previously rejected as syntax errors).
- [x] Row cap fires exactly: configure `max_result_rows: 1`, unbounded `SELECT` returns 1 row, `Truncated.Reason = "max_result_rows"`, second content block present.
- [x] Byte cap fires first on wide rows: `max_result_bytes: 64` against `SELECT number, repeat('x', 100) ...` yields `Truncated.Reason = "max_result_bytes"`, notice mentions `SELECT *`.
- [x] Caps disabled (`-1`): unbounded `SELECT ... LIMIT 1000` returns 1000 rows, no truncation, no notice block.
- [x] `write_query` (INSERT/CREATE) unaffected — no settings injected, no truncation flag.
- [x] OpenAPI: `X-MCP-Truncated` header set + body `truncated` field populated.
- [ ] Post-merge: build image with `scripts/build-mcp-image.sh`, deploy to `otel`, run `test-mcp-connector` subagent (claude.ai only, cleanup always). Pass criteria: `whoami` returns email; `execute_query "SELECT number FROM system.numbers LIMIT 10000"` returns the default 500 rows + truncation notice; `execute_query "DESCRIBE system.tables"` succeeds (regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)