### PR TITLE
chore: drop Altinity/clickhouse-go fork → upstream ClickHouse/clickhouse-go v2.46.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/AfterShip/clickhouse-sql-parser v0.5.1
-	github.com/Altinity/clickhouse-go/v2 v2.45.1-0.20260424134931-fb5f38b1cac7
+	github.com/ClickHouse/clickhouse-go/v2 v2.46.0
 	github.com/franchb/embedded-clickhouse v0.4.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,9 @@
 github.com/AfterShip/clickhouse-sql-parser v0.5.1 h1:Re4BZXx0v4zVKvtumqwFSVy6Xmaui6QT/OgYL6zM3aI=
 github.com/AfterShip/clickhouse-sql-parser v0.5.1/go.mod h1:Qi3qvPTfZb/aFwI5V4WFOahgjsLJa4MzVijIAfwOhDw=
-github.com/Altinity/clickhouse-go/v2 v2.45.1-0.20260424134931-fb5f38b1cac7 h1:/vBQtlgdQ2URiFPjIxHwF0YUnAEkwk87B/edeu/G36Q=
-github.com/Altinity/clickhouse-go/v2 v2.45.1-0.20260424134931-fb5f38b1cac7/go.mod h1:SqvoxopcNPeJWv3lSv3hpBYlwanQ24hWkorGjEWKmdg=
 github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoyRM=
 github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
-github.com/ClickHouse/clickhouse-go/v2 v2.44.0 h1:9pxs5pRwIvhni5BDRPn/n5A8DeUod5TnBaeulFBX8EQ=
-github.com/ClickHouse/clickhouse-go/v2 v2.44.0/go.mod h1:giJfUVlMkcfUEPVfRpt51zZaGEx9i17gCos8gBl392c=
+github.com/ClickHouse/clickhouse-go/v2 v2.46.0 h1:s3eRy+hYmu5uzotB6ZhDofgHu8kDgGN/fpmjxRkqSpk=
+github.com/ClickHouse/clickhouse-go/v2 v2.46.0/go.mod h1:giJfUVlMkcfUEPVfRpt51zZaGEx9i17gCos8gBl392c=
 github.com/altinity/go-mcp-oauth-sdk v0.1.1-0.20260527145654-bdefa859fd1b h1:b6XHGgSAedsoRet5sahr4YABFC2tG+0Imd+8JGx16SY=
 github.com/altinity/go-mcp-oauth-sdk v0.1.1-0.20260527145654-bdefa859fd1b/go.mod h1:yLgv0x586vIzPB5JaA6DkqQsSe4PLRT3PhU2iHO7qsI=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=

--- a/pkg/clickhouse/client.go
+++ b/pkg/clickhouse/client.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Altinity/clickhouse-go/v2"
-	"github.com/Altinity/clickhouse-go/v2/lib/driver"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/altinity/altinity-mcp/pkg/config"
 	"github.com/rs/zerolog/log"
 )

--- a/pkg/server/embedded_xml_config_test.go
+++ b/pkg/server/embedded_xml_config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/Altinity/clickhouse-go/v2"
+	_ "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
## What

Swaps the `github.com/Altinity/clickhouse-go/v2` fork back to upstream `github.com/ClickHouse/clickhouse-go/v2` (latest stable, **v2.46.0**).

## Why

The fork was adopted for a **single reason**: client-side interserver-secret (`cluster_secret`) authentication (#86, commits `dea9214`/`5c20414`). That feature was later **dropped** in favor of the `ch-jwt-verify` sidecar (`49ecb42`). Research confirms the only substantive fork delta is that interserver-secret patch — and we use **zero** fork-only symbols. Everything in use (HTTP Bearer/JWT auth, `__exception__` parsing, `TransportFunc`, `DialStrategy`, `HttpHeaders`) is upstream-identical.

Returning to upstream gets us upstream security fixes + dependabot with nothing to rebase or maintain.

## Changes

- `pkg/clickhouse/client.go` — two import lines rewritten (the only production file importing the driver).
- `pkg/server/embedded_xml_config_test.go` — blank driver-registration import rewritten.
- `go.mod` / `go.sum` — fork `require` replaced with upstream `v2.46.0`; `go mod tidy`.
- The `cluster_secret` `RemovedConfigKeys` deprecation entry (`pkg/config/config.go`) is intentionally left as-is.

> A `go.mod` `replace` shim does **not** work here — Go's internal-package rule breaks across differing module paths. This is a real import-path rewrite.

## Verification

- `go build ./...` — clean.
- `go test ./...` — all green, incl. `pkg/clickhouse` and the embedded-ClickHouse-backed `pkg/server` suite.
- **E2E on live `otel`** (image `chore-drop-clickhouse-go-fork-86825b1`, helm rev 96): via claude.ai against `/mcp/otel` —
  - `whoami` → non-empty email ✅
  - `execute_query` `SELECT 1` → `1` ✅; `SELECT count() FROM system.tables` → `215` ✅
  - Confirms the runtime OAuth→ClickHouse HTTP auth path (bearer → `Basic base64(email:JWT)` → `ch-jwt-verify` sidecar) still works on upstream.

## Risk

Low. The interserver patch is untouched; all used paths are upstream-identical. Rollback is a branch revert (fork still published at its pinned pseudo-version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)