### PR TITLE
test(embeddedch): raise start timeout 60s→120s to de-flake CI

### DIFF
--- a/internal/testutil/embeddedch/embeddedch.go
+++ b/internal/testutil/embeddedch/embeddedch.go
@@ -82,7 +82,7 @@ func WithTCPProtocol() Option {
 	return func(o *Options) { o.Protocol = config.TCPProtocol }
 }
 
-// WithStartTimeout overrides the default 60s start timeout.
+// WithStartTimeout overrides the default 120s start timeout.
 func WithStartTimeout(d time.Duration) Option {
 	return func(o *Options) { o.StartTimeout = d }
 }
@@ -105,8 +105,13 @@ func Setup(t *testing.T, opts ...Option) *config.ClickHouseConfig {
 	}
 
 	o := Options{
-		Protocol:     config.HTTPProtocol,
-		StartTimeout: 60 * time.Second,
+		Protocol: config.HTTPProtocol,
+		// 120s, not 60s: CI runs the suite with `-parallel 4 -shuffle`, so up to
+		// four real ClickHouse servers start concurrently on a cold runner that
+		// may also still be extracting the downloaded binary. 60s intermittently
+		// timed out at Start() (flaky release-build failures); 120s absorbs the
+		// contention without masking a genuine startup error (those fail fast).
+		StartTimeout: 120 * time.Second,
 	}
 	for _, fn := range opts {
 		fn(&o)


### PR DESCRIPTION
The embedded-ClickHouse `Start()` intermittently times out at 60s in CI — it caused the **v1.6.0 release build** to fail (`TestEmbeddedClickHouseXMLDropIn`, `embeddedch.go:152`).

**Cause:** CI runs the suite with `-parallel 4 -shuffle`, so up to four real ClickHouse servers start concurrently on a cold runner that may also still be extracting the downloaded binary. 60s is too tight under that contention.

**Fix:** raise the default `StartTimeout` to 120s. A genuinely bad config still fails *fast* with a CH error, so this absorbs the timing flake without masking real startup failures. Pre-existing test/harness — no behavior change to the product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)