### PR TITLE
cimd: tolerate unknown grant_types in client metadata (fix claude.ai outage)

### DIFF
--- a/cmd/altinity-mcp/cimd.go
+++ b/cmd/altinity-mcp/cimd.go
@@ -483,17 +483,20 @@ func parseCIMDMetadata(clientIDURL string, body []byte) (*statelessRegisteredCli
 			switch gt {
 			case "authorization_code":
 				hasAuthCode = true
-			case "refresh_token":
-				// Tolerated in metadata, deliberately NOT honored in v1: a client
-				// publishing ["authorization_code","refresh_token"] (which
-				// claude.ai does today) silently gets no refresh capability —
-				// .well-known/oauth-authorization-server only advertises
-				// authorization_code and /token returns unsupported_grant_type
-				// for refresh. If/when refresh ships, do NOT treat the CIMD
-				// grant_types array as authoritative for what we issue — the AS
-				// metadata is the source of truth.
 			default:
-				return nil, fmt.Errorf("%w: unsupported grant_type %q", errCIMDInvalidMetadata, gt)
+				// Any other grant_type (refresh_token, and as of 2026-06 claude.ai
+				// also publishes urn:ietf:params:oauth:grant-type:jwt-bearer) is
+				// TOLERATED but deliberately NOT honored in v1. The CIMD grant_types
+				// array is advertising what the *client* can do, not what we issue:
+				// .well-known/oauth-authorization-server only lists authorization_code
+				// and /token returns unsupported_grant_type for everything else, so a
+				// client gets exactly the capabilities the AS metadata declares
+				// regardless of what it lists here. Hard-rejecting unknown entries
+				// just breaks resolution whenever a client adds a new grant_type to
+				// its published doc (this is what took claude.ai connectors down when
+				// jwt-bearer was added). Requiring authorization_code to be present is
+				// the only real constraint. If refresh ever ships, the AS metadata —
+				// not this array — remains the source of truth for what we issue.
 			}
 		}
 		if !hasAuthCode {

--- a/cmd/altinity-mcp/cimd_test.go
+++ b/cmd/altinity-mcp/cimd_test.go
@@ -160,7 +160,7 @@ func TestParseCIMDMetadata_OK(t *testing.T) {
 		"client_name": "Claude",
 		"client_uri": "https://claude.ai",
 		"redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
-		"grant_types": ["authorization_code","refresh_token"],
+		"grant_types": ["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:jwt-bearer"],
 		"response_types": ["code"],
 		"token_endpoint_auth_method": "none"
 	}`)
@@ -183,7 +183,10 @@ func TestParseCIMDMetadata_Reject(t *testing.T) {
 		"empty_redirect_uris":     `{"client_id":"` + u + `","client_name":"X","redirect_uris":[],"token_endpoint_auth_method":"none"}`,
 		"duplicate_redirect_uris": `{"client_id":"` + u + `","client_name":"X","redirect_uris":["https://x/cb","https://x/cb"],"token_endpoint_auth_method":"none"}`,
 		"http_redirect_uri":       `{"client_id":"` + u + `","client_name":"X","redirect_uris":["http://x/cb"],"token_endpoint_auth_method":"none"}`,
-		"unsupported_grant":       `{"client_id":"` + u + `","client_name":"X","redirect_uris":["https://x/cb"],"token_endpoint_auth_method":"none","grant_types":["password"]}`,
+		// Unknown grant_types are now TOLERATED (claude.ai publishes jwt-bearer);
+		// this case still rejects, but because authorization_code is absent — not
+		// because "password" itself is unsupported. See parseCIMDMetadata.
+		"grant_types_without_authcode": `{"client_id":"` + u + `","client_name":"X","redirect_uris":["https://x/cb"],"token_endpoint_auth_method":"none","grant_types":["password"]}`,
 		"unsupported_response":    `{"client_id":"` + u + `","client_name":"X","redirect_uris":["https://x/cb"],"token_endpoint_auth_method":"none","response_types":["token"]}`,
 		"empty_name":              `{"client_id":"` + u + `","client_name":"","redirect_uris":["https://x/cb"],"token_endpoint_auth_method":"none"}`,
 		"oversize_name":           `{"client_id":"` + u + `","client_name":"` + strings.Repeat("a", cimdMaxClientNameLength+1) + `","redirect_uris":["https://x/cb"],"token_endpoint_auth_method":"none"}`,


### PR DESCRIPTION
## Problem

claude.ai changed its published CIMD client metadata document to advertise a third grant type:

```json
"grant_types":["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:jwt-bearer"]
```

The `grant_types` validator in `parseCIMDMetadata` (`cmd/altinity-mcp/cimd.go`) had a hard allowlist of `{authorization_code, refresh_token}` with a `default:` branch that **rejected the entire metadata document** on any other entry. Result: every claude.ai connector failed at `/oauth/authorize` with

```
cimd: invalid metadata document: unsupported grant_type "urn:ietf:params:oauth:grant-type:jwt-bearer"
```

surfacing client-side as `{"error":"invalid_client","error_description":"unknown OAuth client"}`. ChatGPT was unaffected (its `client.json` lists no extra grants). This is the same failure class as the earlier `private_key_jwt` rejection (#119): a too-strict CIMD parser breaks the moment a first-party client adds a field.

## Fix

The CIMD `grant_types` array advertises **client** capability, not what we issue. `.well-known/oauth-authorization-server` only lists `authorization_code` and `/oauth/token` returns `unsupported_grant_type` for everything else, so tolerating unknown entries changes nothing about issued tokens. The `default:` branch now ignores unknown grant_types; the only retained constraint is that `authorization_code` must be present.

## Tests

- `TestParseCIMDMetadata_OK` updated to carry claude.ai's real 3-element array (incl. `jwt-bearer`) as a regression guard.
- The former `unsupported_grant` reject case renamed `grant_types_without_authcode` — it still rejects, but now because `authorization_code` is absent, not because the other grant is unknown.
- Full `./cmd/altinity-mcp/` suite green.

## Deployment

Built arm64 and deployed to the live `github-mcp` fleet (`mcp.demo.altinity.cloud`, serving `/mcp/antalya` + `/mcp/github`) as `fix-cimd-grant-types-99f0e05-arm64`. Verified: `/authorize` with claude.ai's client_id now 302-redirects to Google, and the antalya connector reconnects successfully in claude.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)