### PR TITLE
Add separate TCP dial address for ClickHouse connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ logging:
   level: "info"
 ```
 
+When `connect_host` is set, it takes precedence over `HTTP_PROXY` and
+`HTTPS_PROXY` for ClickHouse HTTP connections so the configured address is
+always the TCP destination. Environment proxy behavior is unchanged when
+`connect_host` is empty.
+
 > **Note**: For detailed information about dynamic tools configuration, see the [Tools Documentation](docs/tools.md).
 
 Use the configuration file:

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Create a YAML or JSON configuration file:
 # config.yaml
 clickhouse:
   host: "localhost"
+  # Optional TCP destination override. The logical host above remains the
+  # HTTP Host header and TLS SNI/certificate verification name.
+  connect_host: ""
   port: 8123
   database: "default"
   username: "default"
@@ -433,6 +436,7 @@ For the full OAuth setup and ClickHouse-specific details, see the [OAuth 2.0 Aut
 ### ClickHouse® Flags
 
 - `--clickhouse-host`: ClickHouse® server host
+- `--clickhouse-connect-host`: Optional hostname or IP used only for the underlying TCP connection (`CLICKHOUSE_CONNECT_HOST`)
 - `--clickhouse-port`: ClickHouse® server port
 - `--clickhouse-database`: Database name
 - `--clickhouse-username`: Username

--- a/cmd/altinity-mcp/main.go
+++ b/cmd/altinity-mcp/main.go
@@ -765,6 +765,9 @@ func buildConfig(cmd CommandInterface) (config.Config, error) {
 	// Override with CLI flags (CLI flags take precedence over config file)
 	overrideWithCLIFlags(&cfg, cmd)
 	config.ApplyMulticlusterDefaults(&cfg)
+	if err := cfg.ClickHouse.ValidateConnectHost(); err != nil {
+		return cfg, err
+	}
 	if logErr := setupLogging(string(cfg.Logging.Level)); logErr != nil {
 		return cfg, fmt.Errorf("failed setup logging %s level: %w", cfg.Logging.Level, logErr)
 	}
@@ -1299,6 +1302,9 @@ func (a *application) reloadConfig(cmd CommandInterface) error {
 
 	// Override with CLI flags
 	overrideWithCLIFlags(newCfg, cmd)
+	if err := newCfg.ClickHouse.ValidateConnectHost(); err != nil {
+		return err
+	}
 
 	// multicluster.* fields are restart-only: the router + catalog cache
 	// were bound during newApplication and cannot be safely rebuilt

--- a/cmd/altinity-mcp/main_test.go
+++ b/cmd/altinity-mcp/main_test.go
@@ -845,6 +845,22 @@ func TestReloadConfig(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to load config file")
 	})
+
+	t.Run("invalid_connect_host_preserves_active_config", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("clickhouse:\n  connect_host: https://10.0.0.25\n"), 0o600))
+		oldCfg := config.Config{ClickHouse: config.ClickHouseConfig{Host: "old.example", ConnectHost: "10.0.0.10"}}
+		app := &application{
+			configFile: path,
+			config:     oldCfg,
+			mcpServer:  altinitymcp.NewClickHouseMCPServer(oldCfg, "test-version"),
+		}
+		err := app.reloadConfig(&mockCommand{flags: map[string]interface{}{}, setFlags: map[string]bool{}, stringMaps: map[string]map[string]string{}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "clickhouse.connect_host")
+		require.Equal(t, oldCfg.ClickHouse, app.GetCurrentConfig().ClickHouse)
+	})
 }
 
 // TestTestConnection tests the testConnection function
@@ -1374,6 +1390,7 @@ func TestBuildConfigWithFile(t *testing.T) {
 reload_time: 10
 clickhouse:
   host: "config-host"
+  connect_host: "10.0.0.25"
   port: 9000
   database: "config-db"
   http_headers:
@@ -1422,6 +1439,7 @@ logging:
 
 		// CLI flag should override config file
 		require.Equal(t, "cli-host", cfg.ClickHouse.Host)
+		require.Equal(t, "10.0.0.25", cfg.ClickHouse.ConnectHost)
 		// Config file values should be used where CLI flags aren't set
 		require.Equal(t, 9000, cfg.ClickHouse.Port)
 		require.Equal(t, "config-db", cfg.ClickHouse.Database)
@@ -1439,6 +1457,40 @@ logging:
 
 		// Verify reload time was preserved from CLI flag (not overwritten by config file)
 		require.Equal(t, 10, cfg.ReloadTime)
+	})
+
+	t.Run("rejects_invalid_connect_host_after_overrides", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("clickhouse:\n  connect_host: proxy.internal/path\n"), 0o600))
+		cmd := &mockCommand{
+			flags:      map[string]interface{}{"config": path},
+			setFlags:   map[string]bool{"config": true},
+			stringMaps: map[string]map[string]string{},
+		}
+		_, err := buildConfig(cmd)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "clickhouse.connect_host")
+	})
+
+	t.Run("cli_connect_host_overrides_invalid_file_value_before_validation", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("clickhouse:\n  connect_host: proxy.internal/path\n"), 0o600))
+		cmd := &mockCommand{
+			flags: map[string]interface{}{
+				"config":                  path,
+				"clickhouse-connect-host": "10.0.0.25",
+			},
+			setFlags: map[string]bool{
+				"config":                  true,
+				"clickhouse-connect-host": true,
+			},
+			stringMaps: map[string]map[string]string{},
+		}
+		cfg, err := buildConfig(cmd)
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.25", cfg.ClickHouse.ConnectHost)
 	})
 
 	t.Run("with_http_headers_cli_override", func(t *testing.T) {

--- a/helm/altinity-mcp/README.md
+++ b/helm/altinity-mcp/README.md
@@ -13,7 +13,7 @@ A Helm chart for Altinity MCP Server
 | autoscaling.maxReplicas | int | `100` | Maximum number of replicas |
 | autoscaling.minReplicas | int | `1` | Minimum number of replicas |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage |
-| config.clickhouse.connect_host | string | `""` | Optional static hostname or IP used only to open the TCP connection. HTTP Host, TLS SNI, and certificate verification continue to use `host`. In multi-cluster mode this value is not subject to {cluster} substitution. |
+| config.clickhouse.connect_host | string | `""` | Optional static hostname or IP used only to open the TCP connection. HTTP Host, TLS SNI, and certificate verification continue to use `host`. In multi-cluster mode this value is not subject to {cluster} substitution. When set, it takes precedence over HTTP_PROXY/HTTPS_PROXY for ClickHouse. |
 | config.clickhouse.database | string | `"default"` |  |
 | config.clickhouse.host | string | `"localhost"` |  |
 | config.clickhouse.limit | int | `1000` |  |

--- a/helm/altinity-mcp/README.md
+++ b/helm/altinity-mcp/README.md
@@ -13,6 +13,7 @@ A Helm chart for Altinity MCP Server
 | autoscaling.maxReplicas | int | `100` | Maximum number of replicas |
 | autoscaling.minReplicas | int | `1` | Minimum number of replicas |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage |
+| config.clickhouse.connect_host | string | `""` | Optional static hostname or IP used only to open the TCP connection. HTTP Host, TLS SNI, and certificate verification continue to use `host`. In multi-cluster mode this value is not subject to {cluster} substitution. |
 | config.clickhouse.database | string | `"default"` |  |
 | config.clickhouse.host | string | `"localhost"` |  |
 | config.clickhouse.limit | int | `1000` |  |

--- a/helm/altinity-mcp/values.yaml
+++ b/helm/altinity-mcp/values.yaml
@@ -159,6 +159,10 @@ config:
     #   host: "chi-{cluster}-{cluster}-0-0.demo"
     # Single-cluster: use the static hostname directly.
     host: "localhost"
+    # -- Optional static hostname or IP used only to open the TCP connection.
+    # HTTP Host, TLS SNI, and certificate verification continue to use `host`.
+    # In multi-cluster mode this value is not subject to {cluster} substitution.
+    connect_host: ""
     port: 8123
     database: "default"
     username: "default"

--- a/helm/altinity-mcp/values.yaml
+++ b/helm/altinity-mcp/values.yaml
@@ -162,6 +162,7 @@ config:
     # -- Optional static hostname or IP used only to open the TCP connection.
     # HTTP Host, TLS SNI, and certificate verification continue to use `host`.
     # In multi-cluster mode this value is not subject to {cluster} substitution.
+    # When set, it takes precedence over HTTP_PROXY/HTTPS_PROXY for ClickHouse.
     connect_host: ""
     port: 8123
     database: "default"

--- a/helm/altinity-mcp/values_examples/mcp-multicluster.yaml
+++ b/helm/altinity-mcp/values_examples/mcp-multicluster.yaml
@@ -5,7 +5,8 @@
 #   https://<ingress.host>/mcp/{cluster}
 # where {cluster} is one of `cluster_allowlist` and the literal
 # `{cluster}` placeholder in clickhouse.host is substituted at request
-# time. All other clickhouse.* fields are shared across clusters.
+# time. connect_host, when set, remains a static TCP destination shared by
+# all logical cluster hosts. All other clickhouse.* fields are also shared.
 #
 # Pre-requisites in the demo namespace:
 #   * Each ClickHouse pod (cluster otel, antalya, ...) must have the
@@ -25,6 +26,9 @@ config:
     # cluster name from /mcp/{cluster} (RFC 1123 DNS label, must appear
     # in cluster_allowlist below).
     host: "chi-{cluster}-{cluster}-0-0.demo"
+    # Optional fixed network destination. HTTP Host, TLS SNI, and certificate
+    # validation continue to use the cluster-expanded logical host above.
+    connect_host: "10.0.0.25"
     port: 8443
     protocol: "http"
     read_only: false

--- a/pkg/clickhouse/client.go
+++ b/pkg/clickhouse/client.go
@@ -5,9 +5,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -74,6 +76,9 @@ type Client struct {
 
 // NewClient creates a new ClickHouse client
 func NewClient(ctx context.Context, cfg config.ClickHouseConfig) (*Client, error) {
+	if err := cfg.ValidateConnectHost(); err != nil {
+		return nil, err
+	}
 	clickhouseCtx, cancel := context.WithCancel(ctx)
 	client := &Client{
 		config:     cfg,
@@ -132,7 +137,6 @@ func (c *Client) connect() error {
 	}
 
 	opts := &clickhouse.Options{
-		Addr:            []string{fmt.Sprintf("%s:%d", c.config.Host, c.config.Port)},
 		Auth:            auth,
 		TLS:             tlsConfig,
 		Protocol:        protocol,
@@ -145,6 +149,7 @@ func (c *Client) connect() error {
 		ConnMaxLifetime: time.Hour,
 		DialStrategy:    dialWithoutQueryDeadline,
 	}
+	configureDialOverride(opts, c.config, protocol, tlsConfig)
 
 	// Per-request role activation: append repeated `role=` query params to every
 	// HTTP request. The driver's Settings map is single-valued and serialized
@@ -189,6 +194,38 @@ func (c *Client) connect() error {
 	}
 
 	return nil
+}
+
+// configureDialOverride keeps the driver-facing address logical while
+// optionally replacing only the underlying ClickHouse TCP destination.
+func configureDialOverride(opts *clickhouse.Options, cfg config.ClickHouseConfig, protocol clickhouse.Protocol, tlsConfig *tls.Config) {
+	logicalAddress := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+	opts.Addr = []string{logicalAddress}
+	if cfg.ConnectHost == "" {
+		return
+	}
+
+	dialAddress := net.JoinHostPort(cfg.ConnectHost, strconv.Itoa(cfg.Port))
+	netDialer := &net.Dialer{Timeout: opts.DialTimeout}
+	if tlsConfig != nil {
+		// The logical host, rather than the alternate TCP destination,
+		// remains the TLS SNI and certificate-verification identity.
+		tlsConfig.ServerName = cfg.Host
+	}
+	opts.DialContext = func(ctx context.Context, addr string) (net.Conn, error) {
+		target := addr
+		if addr == logicalAddress {
+			target = dialAddress
+		}
+
+		// clickhouse-go performs HTTP TLS after DialContext returns, but a
+		// native custom dialer must perform the TLS handshake itself.
+		if protocol == clickhouse.Native && tlsConfig != nil {
+			tlsDialer := &tls.Dialer{NetDialer: netDialer, Config: tlsConfig}
+			return tlsDialer.DialContext(ctx, "tcp", target)
+		}
+		return netDialer.DialContext(ctx, "tcp", target)
+	}
 }
 
 // clickhouse-go derives max_execution_time from connection-establishment context

--- a/pkg/clickhouse/client.go
+++ b/pkg/clickhouse/client.go
@@ -150,19 +150,7 @@ func (c *Client) connect() error {
 		DialStrategy:    dialWithoutQueryDeadline,
 	}
 	configureDialOverride(opts, c.config, protocol, tlsConfig)
-
-	// Per-request role activation: append repeated `role=` query params to every
-	// HTTP request. The driver's Settings map is single-valued and serialized
-	// with url.Values.Set, so it can't express `?role=a&role=b`; wrapping the
-	// transport is the supported way. TransportFunc is HTTP-only in the driver
-	// (native TCP ignores it) — OAuth mode runs over HTTP, and the caller
-	// refuses role activation on non-HTTP protocols.
-	if len(c.config.Roles) > 0 {
-		roles := append([]string(nil), c.config.Roles...)
-		opts.TransportFunc = func(t *http.Transport) (http.RoundTripper, error) {
-			return &roleRoundTripper{wrapped: t, roles: roles}, nil
-		}
-	}
+	configureHTTPTransport(opts, c.config, protocol)
 
 	conn, openErr := clickhouse.Open(opts)
 
@@ -199,7 +187,8 @@ func (c *Client) connect() error {
 // configureDialOverride keeps the driver-facing address logical while
 // optionally replacing only the underlying ClickHouse TCP destination.
 func configureDialOverride(opts *clickhouse.Options, cfg config.ClickHouseConfig, protocol clickhouse.Protocol, tlsConfig *tls.Config) {
-	logicalAddress := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+	logicalHost := normalizeLogicalHost(cfg.Host)
+	logicalAddress := net.JoinHostPort(logicalHost, strconv.Itoa(cfg.Port))
 	opts.Addr = []string{logicalAddress}
 	if cfg.ConnectHost == "" {
 		return
@@ -210,7 +199,7 @@ func configureDialOverride(opts *clickhouse.Options, cfg config.ClickHouseConfig
 	if tlsConfig != nil {
 		// The logical host, rather than the alternate TCP destination,
 		// remains the TLS SNI and certificate-verification identity.
-		tlsConfig.ServerName = cfg.Host
+		tlsConfig.ServerName = logicalHost
 	}
 	opts.DialContext = func(ctx context.Context, addr string) (net.Conn, error) {
 		target := addr
@@ -225,6 +214,45 @@ func configureDialOverride(opts *clickhouse.Options, cfg config.ClickHouseConfig
 			return tlsDialer.DialContext(ctx, "tcp", target)
 		}
 		return netDialer.DialContext(ctx, "tcp", target)
+	}
+}
+
+// normalizeLogicalHost preserves compatibility with configurations that used
+// bracketed IPv6 with the previous host:port formatter. net.JoinHostPort and
+// tls.Config.ServerName both require the host without brackets.
+func normalizeLogicalHost(host string) string {
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		candidate := host[1 : len(host)-1]
+		ipCandidate := candidate
+		if zoneAt := strings.LastIndexByte(ipCandidate, '%'); zoneAt >= 0 {
+			ipCandidate = ipCandidate[:zoneAt]
+		}
+		if net.ParseIP(ipCandidate) != nil {
+			return candidate
+		}
+	}
+	return host
+}
+
+// configureHTTPTransport composes ClickHouse-specific transport behavior in a
+// single hook. An explicit connect_host takes precedence over environment
+// proxies so it remains the actual TCP destination; with no override, the
+// driver's existing ProxyFromEnvironment behavior is preserved. Role query
+// injection wraps the resulting transport rather than replacing it.
+func configureHTTPTransport(opts *clickhouse.Options, cfg config.ClickHouseConfig, protocol clickhouse.Protocol) {
+	if protocol != clickhouse.HTTP || (cfg.ConnectHost == "" && len(cfg.Roles) == 0) {
+		return
+	}
+
+	roles := append([]string(nil), cfg.Roles...)
+	opts.TransportFunc = func(t *http.Transport) (http.RoundTripper, error) {
+		if cfg.ConnectHost != "" {
+			t.Proxy = nil
+		}
+		if len(roles) > 0 {
+			return &roleRoundTripper{wrapped: t, roles: roles}, nil
+		}
+		return t, nil
 	}
 }
 

--- a/pkg/clickhouse/client_test.go
+++ b/pkg/clickhouse/client_test.go
@@ -30,6 +30,24 @@ func TestConfigureDialOverride(t *testing.T) {
 		require.Empty(t, tlsConfig.ServerName)
 	})
 
+	t.Run("bracketed_logical_ipv6_is_normalized", func(t *testing.T) {
+		t.Parallel()
+		opts := &chdriver.Options{DialTimeout: time.Second}
+		unsetTLSConfig := &tls.Config{}
+		configureDialOverride(opts, config.ClickHouseConfig{Host: "[2001:db8::10]", Port: 8443}, chdriver.Native, unsetTLSConfig)
+		require.Equal(t, []string{"[2001:db8::10]:8443"}, opts.Addr)
+		require.Nil(t, opts.DialContext)
+		require.Empty(t, unsetTLSConfig.ServerName)
+
+		tlsConfig := &tls.Config{}
+		configureDialOverride(opts, config.ClickHouseConfig{
+			Host: "[2001:db8::10]", ConnectHost: "10.0.0.25", Port: 8443,
+		}, chdriver.Native, tlsConfig)
+		require.Equal(t, []string{"[2001:db8::10]:8443"}, opts.Addr)
+		require.NotNil(t, opts.DialContext)
+		require.Equal(t, "2001:db8::10", tlsConfig.ServerName)
+	})
+
 	t.Run("non_clickhouse_destination_is_not_redirected", func(t *testing.T) {
 		t.Parallel()
 		listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -57,6 +75,130 @@ func TestConfigureDialOverride(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("unrelated destination was not dialed")
 		}
+	})
+
+	t.Run("connect_host_equal_to_logical_host", func(t *testing.T) {
+		t.Parallel()
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer listener.Close()
+		host, portString, err := net.SplitHostPort(listener.Addr().String())
+		require.NoError(t, err)
+		port, err := strconv.Atoi(portString)
+		require.NoError(t, err)
+
+		opts := &chdriver.Options{DialTimeout: time.Second}
+		configureDialOverride(opts, config.ClickHouseConfig{Host: host, ConnectHost: host, Port: port}, chdriver.HTTP, nil)
+		conn, err := opts.DialContext(context.Background(), opts.Addr[0])
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	})
+
+	t.Run("ipv6_connect_host_is_joined_and_dialed", func(t *testing.T) {
+		t.Parallel()
+		listener, err := net.Listen("tcp6", "[::1]:0")
+		if err != nil {
+			t.Skipf("IPv6 loopback is unavailable: %v", err)
+		}
+		defer listener.Close()
+		_, portString, err := net.SplitHostPort(listener.Addr().String())
+		require.NoError(t, err)
+		port, err := strconv.Atoi(portString)
+		require.NoError(t, err)
+
+		opts := &chdriver.Options{DialTimeout: time.Second}
+		configureDialOverride(opts, config.ClickHouseConfig{
+			Host: "logical.invalid", ConnectHost: "::1", Port: port,
+		}, chdriver.HTTP, nil)
+		conn, err := opts.DialContext(context.Background(), opts.Addr[0])
+		require.NoError(t, err)
+		require.Equal(t, "[::1]:"+portString, conn.RemoteAddr().String())
+		require.NoError(t, conn.Close())
+	})
+}
+
+func TestConnectHostDisablesEnvironmentProxyAndComposesRoles(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+	t.Setenv("NO_PROXY", "")
+
+	for _, useTLS := range []bool{false, true} {
+		useTLS := useTLS
+		name := "http_proxy"
+		if useTLS {
+			name = "https_proxy"
+		}
+		t.Run(name, func(t *testing.T) {
+			observed := make(chan *http.Request, 1)
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				observed <- r.Clone(r.Context())
+				w.WriteHeader(http.StatusOK)
+			}))
+			if useTLS {
+				server.StartTLS()
+			} else {
+				server.Start()
+			}
+			defer server.Close()
+
+			connectHost, portString, err := net.SplitHostPort(server.Listener.Addr().String())
+			require.NoError(t, err)
+			port, err := strconv.Atoi(portString)
+			require.NoError(t, err)
+			logicalHost := "logical.invalid"
+			var tlsConfig *tls.Config
+			if useTLS {
+				require.NotEmpty(t, server.Certificate().DNSNames)
+				logicalHost = server.Certificate().DNSNames[0]
+				roots := x509.NewCertPool()
+				roots.AddCert(server.Certificate())
+				tlsConfig = &tls.Config{RootCAs: roots}
+			}
+
+			cfg := config.ClickHouseConfig{
+				Host: logicalHost, ConnectHost: connectHost, Port: port,
+				Protocol: config.HTTPProtocol, Roles: []string{"analyst"},
+			}
+			opts := &chdriver.Options{DialTimeout: time.Second}
+			configureDialOverride(opts, cfg, chdriver.HTTP, tlsConfig)
+			configureHTTPTransport(opts, cfg, chdriver.HTTP)
+			require.NotNil(t, opts.TransportFunc)
+
+			baseTransport := &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
+				TLSClientConfig: tlsConfig,
+				DialContext: func(ctx context.Context, _ string, addr string) (net.Conn, error) {
+					return opts.DialContext(ctx, addr)
+				},
+			}
+			roundTripper, err := opts.TransportFunc(baseTransport)
+			require.NoError(t, err)
+			require.Nil(t, baseTransport.Proxy, "connect_host must take precedence over environment proxies")
+			require.IsType(t, &roleRoundTripper{}, roundTripper)
+
+			scheme := "http"
+			if useTLS {
+				scheme = "https"
+			}
+			client := &http.Client{Transport: roundTripper, Timeout: 2 * time.Second}
+			resp, err := client.Get(scheme + "://" + opts.Addr[0] + "/")
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+			got := <-observed
+			require.Equal(t, logicalHost+":"+portString, got.Host)
+			require.Equal(t, "analyst", got.URL.Query().Get("role"))
+		})
+	}
+
+	t.Run("unset_preserves_proxy_selection", func(t *testing.T) {
+		cfg := config.ClickHouseConfig{Roles: []string{"analyst"}}
+		opts := &chdriver.Options{}
+		configureHTTPTransport(opts, cfg, chdriver.HTTP)
+		require.NotNil(t, opts.TransportFunc)
+		baseTransport := &http.Transport{Proxy: http.ProxyFromEnvironment}
+		_, err := opts.TransportFunc(baseTransport)
+		require.NoError(t, err)
+		require.NotNil(t, baseTransport.Proxy)
 	})
 }
 
@@ -139,6 +281,10 @@ func TestConnectHostNativeTLSUsesLogicalCertificateName(t *testing.T) {
 }
 
 func TestConnectHostPlainProtocols(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+	t.Setenv("NO_PROXY", "")
+
 	for _, protocol := range []config.ClickHouseProtocol{config.HTTPProtocol, config.TCPProtocol} {
 		protocol := protocol
 		t.Run(string(protocol), func(t *testing.T) {

--- a/pkg/clickhouse/client_test.go
+++ b/pkg/clickhouse/client_test.go
@@ -2,13 +2,159 @@ package clickhouse
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
+	chdriver "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/altinity/altinity-mcp/internal/testutil/embeddedch"
 	"github.com/altinity/altinity-mcp/pkg/config"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConfigureDialOverride(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unset_preserves_default_dialing_and_formats_ipv6", func(t *testing.T) {
+		t.Parallel()
+		opts := &chdriver.Options{DialTimeout: time.Second}
+		tlsConfig := &tls.Config{}
+		configureDialOverride(opts, config.ClickHouseConfig{Host: "2001:db8::10", Port: 8443}, chdriver.HTTP, tlsConfig)
+		require.Equal(t, []string{"[2001:db8::10]:8443"}, opts.Addr)
+		require.Nil(t, opts.DialContext)
+		require.Empty(t, tlsConfig.ServerName)
+	})
+
+	t.Run("non_clickhouse_destination_is_not_redirected", func(t *testing.T) {
+		t.Parallel()
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer listener.Close()
+
+		accepted := make(chan struct{})
+		go func() {
+			conn, acceptErr := listener.Accept()
+			if acceptErr == nil {
+				close(accepted)
+				_ = conn.Close()
+			}
+		}()
+
+		opts := &chdriver.Options{DialTimeout: time.Second}
+		configureDialOverride(opts, config.ClickHouseConfig{
+			Host: "logical.example", ConnectHost: "192.0.2.10", Port: 8443,
+		}, chdriver.HTTP, nil)
+		conn, err := opts.DialContext(context.Background(), listener.Addr().String())
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+		select {
+		case <-accepted:
+		case <-time.After(time.Second):
+			t.Fatal("unrelated destination was not dialed")
+		}
+	})
+}
+
+func TestConnectHostHTTPPreservesLogicalHostAndTLSIdentity(t *testing.T) {
+	type observedRequest struct {
+		host       string
+		serverName string
+	}
+	observed := make(chan observedRequest, 1)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observed <- observedRequest{host: r.Host, serverName: r.TLS.ServerName}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	host, portString, err := net.SplitHostPort(server.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portString)
+	require.NoError(t, err)
+	require.NotEmpty(t, server.Certificate().DNSNames)
+	logicalHost := server.Certificate().DNSNames[0]
+
+	roots := x509.NewCertPool()
+	roots.AddCert(server.Certificate())
+	tlsConfig := &tls.Config{RootCAs: roots}
+	opts := &chdriver.Options{DialTimeout: time.Second}
+	configureDialOverride(opts, config.ClickHouseConfig{
+		Host: logicalHost, ConnectHost: host, Port: port,
+	}, chdriver.HTTP, tlsConfig)
+
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+		DialContext: func(ctx context.Context, _ string, addr string) (net.Conn, error) {
+			return opts.DialContext(ctx, addr)
+		},
+	}
+	client := &http.Client{Transport: transport, Timeout: 2 * time.Second}
+	resp, err := client.Get("https://" + opts.Addr[0] + "/")
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	got := <-observed
+	require.Equal(t, logicalHost+":"+portString, got.host)
+	require.Equal(t, logicalHost, got.serverName)
+	require.Equal(t, logicalHost, tlsConfig.ServerName)
+}
+
+func TestConnectHostNativeTLSUsesLogicalCertificateName(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer server.Close()
+
+	host, portString, err := net.SplitHostPort(server.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portString)
+	require.NoError(t, err)
+	require.NotEmpty(t, server.Certificate().DNSNames)
+	logicalHost := server.Certificate().DNSNames[0]
+	roots := x509.NewCertPool()
+	roots.AddCert(server.Certificate())
+
+	t.Run("logical_name_succeeds", func(t *testing.T) {
+		opts := &chdriver.Options{DialTimeout: time.Second}
+		configureDialOverride(opts, config.ClickHouseConfig{
+			Host: logicalHost, ConnectHost: host, Port: port,
+		}, chdriver.Native, &tls.Config{RootCAs: roots})
+		conn, err := opts.DialContext(context.Background(), opts.Addr[0])
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	})
+
+	t.Run("connect_host_identity_is_rejected", func(t *testing.T) {
+		opts := &chdriver.Options{DialTimeout: time.Second}
+		configureDialOverride(opts, config.ClickHouseConfig{
+			Host: "wrong.example", ConnectHost: host, Port: port,
+		}, chdriver.Native, &tls.Config{RootCAs: roots})
+		conn, err := opts.DialContext(context.Background(), opts.Addr[0])
+		require.Error(t, err)
+		require.Nil(t, conn)
+		require.Contains(t, err.Error(), "wrong.example")
+	})
+}
+
+func TestConnectHostPlainProtocols(t *testing.T) {
+	for _, protocol := range []config.ClickHouseProtocol{config.HTTPProtocol, config.TCPProtocol} {
+		protocol := protocol
+		t.Run(string(protocol), func(t *testing.T) {
+			options := []embeddedch.Option{}
+			if protocol == config.TCPProtocol {
+				options = append(options, embeddedch.WithTCPProtocol())
+			}
+			cfg := embeddedch.Setup(t, options...)
+			cfg.ConnectHost = cfg.Host
+			cfg.Host = "logical.invalid"
+			client, err := NewClient(context.Background(), *cfg)
+			require.NoError(t, err)
+			require.NoError(t, client.Close())
+		})
+	}
+}
 
 // setupEmbeddedClickHouse boots a ClickHouse server as a host subprocess via
 // embedded-clickhouse and returns a TCP-protocol config. This replaces the
@@ -21,6 +167,14 @@ func setupEmbeddedClickHouse(t *testing.T) *config.ClickHouseConfig {
 // TestNewClient tests client creation
 func TestNewClient(t *testing.T) {
 	t.Parallel()
+	t.Run("invalid_connect_host", func(t *testing.T) {
+		t.Parallel()
+		client, err := NewClient(context.Background(), config.ClickHouseConfig{ConnectHost: "https://10.0.0.25"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "clickhouse.connect_host")
+		require.Nil(t, client)
+	})
+
 	t.Run("invalid_config", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()

--- a/pkg/config/cli_reflect_test.go
+++ b/pkg/config/cli_reflect_test.go
@@ -1,12 +1,28 @@
 package config
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
 )
+
+func TestBuildFlagsConnectHostEnvironment(t *testing.T) {
+	t.Setenv("CLICKHOUSE_CONNECT_HOST", "2001:db8::10")
+	var cfg Config
+	cmd := &cli.Command{
+		Name:  "test",
+		Flags: BuildFlags(&cfg),
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			ApplyFlags(&cfg, cmd)
+			return nil
+		},
+	}
+	require.NoError(t, cmd.Run(context.Background(), []string{"test"}))
+	require.Equal(t, "2001:db8::10", cfg.ClickHouse.ConnectHost)
+}
 
 // fakeCmd implements Command for tests.
 type fakeCmd struct {
@@ -36,6 +52,7 @@ func TestBuildFlags_ConfigStruct(t *testing.T) {
 
 	// Spot-check a representative cross-section across all sub-structs.
 	require.Contains(t, byName, "clickhouse-host")
+	require.Contains(t, byName, "clickhouse-connect-host")
 	require.Contains(t, byName, "clickhouse-port")
 	require.Contains(t, byName, "clickhouse-tls")
 	require.Contains(t, byName, "clickhouse-http-headers")
@@ -62,6 +79,7 @@ func TestBuildFlags_ConfigStruct(t *testing.T) {
 
 	// Type assertions on a sample of each kind.
 	require.IsType(t, &cli.StringFlag{}, byName["clickhouse-host"])
+	require.IsType(t, &cli.StringFlag{}, byName["clickhouse-connect-host"])
 	require.IsType(t, &cli.IntFlag{}, byName["clickhouse-port"])
 	require.IsType(t, &cli.BoolFlag{}, byName["server-tls"])
 	require.IsType(t, &cli.StringSliceFlag{}, byName["oauth-scopes"])
@@ -83,28 +101,31 @@ func TestApplyFlags_SetsValues(t *testing.T) {
 	cfg := &Config{}
 	cmd := &fakeCmd{
 		strs: map[string]string{
-			"clickhouse-host":      "ch.internal",
-			"oauth-signing-secret": "shh",
-			"transport":            "http",
+			"clickhouse-host":         "ch.internal",
+			"clickhouse-connect-host": "10.0.0.25",
+			"oauth-signing-secret":    "shh",
+			"transport":               "http",
 		},
-		ints:  map[string]int{"clickhouse-port": 9000},
-		bools: map[string]bool{"server-tls": true, "oauth-enabled": true, "oauth-broker": true},
+		ints:   map[string]int{"clickhouse-port": 9000},
+		bools:  map[string]bool{"server-tls": true, "oauth-enabled": true, "oauth-broker": true},
 		slices: map[string][]string{"oauth-required-scopes": {"openid", "email"}},
 		wasSet: map[string]bool{
-			"clickhouse-host":       true,
-			"clickhouse-port":       true,
-			"server-tls":            true,
-			"oauth-enabled":         true,
-			"oauth-signing-secret":  true,
-			"oauth-required-scopes": true,
-			"transport":             true,
-			"oauth-broker":          true,
+			"clickhouse-host":         true,
+			"clickhouse-connect-host": true,
+			"clickhouse-port":         true,
+			"server-tls":              true,
+			"oauth-enabled":           true,
+			"oauth-signing-secret":    true,
+			"oauth-required-scopes":   true,
+			"transport":               true,
+			"oauth-broker":            true,
 		},
 	}
 
 	ApplyFlags(cfg, cmd)
 
 	require.Equal(t, "ch.internal", cfg.ClickHouse.Host)
+	require.Equal(t, "10.0.0.25", cfg.ClickHouse.ConnectHost)
 	require.Equal(t, 9000, cfg.ClickHouse.Port)
 	require.True(t, cfg.Server.TLS.Enabled)
 	require.True(t, cfg.Server.OAuth.Enabled)
@@ -156,14 +177,19 @@ func TestApplyFlags_CLIBeatsYAML(t *testing.T) {
 	t.Parallel()
 	cfg := &Config{}
 	cfg.ClickHouse.Host = "from-yaml.example"
+	cfg.ClickHouse.ConnectHost = "192.0.2.10"
 	cmd := &fakeCmd{
-		strs:   map[string]string{"clickhouse-host": "from-cli.example"},
-		wasSet: map[string]bool{"clickhouse-host": true},
+		strs: map[string]string{
+			"clickhouse-host":         "from-cli.example",
+			"clickhouse-connect-host": "198.51.100.10",
+		},
+		wasSet: map[string]bool{"clickhouse-host": true, "clickhouse-connect-host": true},
 	}
 
 	ApplyFlags(cfg, cmd)
 
 	require.Equal(t, "from-cli.example", cfg.ClickHouse.Host)
+	require.Equal(t, "198.51.100.10", cfg.ClickHouse.ConnectHost)
 }
 
 func TestBuildFlags_Duration_BuildsAndApplies(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,6 +39,7 @@ type TLSConfig struct {
 // ClickHouseConfig defines configuration for connecting to ClickHouse
 type ClickHouseConfig struct {
 	Host             string             `json:"host" yaml:"host" flag:"clickhouse-host" env:"CLICKHOUSE_HOST" default:"localhost" desc:"ClickHouse server host"`
+	ConnectHost      string             `json:"connect_host,omitempty" yaml:"connect_host,omitempty" flag:"clickhouse-connect-host" env:"CLICKHOUSE_CONNECT_HOST" desc:"Alternative host or IP used only to open the TCP connection"`
 	Port             int                `json:"port" yaml:"port" flag:"clickhouse-port" env:"CLICKHOUSE_PORT" default:"8123" desc:"ClickHouse server port"`
 	Database         string             `json:"database" yaml:"database" flag:"clickhouse-database" env:"CLICKHOUSE_DATABASE" default:"default" desc:"ClickHouse database name"`
 	Username         string             `json:"username" yaml:"username" flag:"clickhouse-username" env:"CLICKHOUSE_USERNAME" default:"default" desc:"ClickHouse username"`
@@ -61,6 +63,48 @@ type ClickHouseConfig struct {
 	// MaxQueryLength caps the size in bytes of a single SQL query string sent by a client.
 	// Default 10 MB when 0. Set to a negative number to disable the check.
 	MaxQueryLength int `json:"max_query_length,omitempty" yaml:"max_query_length,omitempty" flag:"clickhouse-max-query-length" env:"CLICKHOUSE_MAX_QUERY_LENGTH" desc:"Max bytes of SQL query string accepted from clients (0=default 10MB, <0=disabled)"`
+}
+
+// ValidateConnectHost checks that ConnectHost contains only a hostname or an
+// unbracketed IP address. The ClickHouse port is configured separately and is
+// deliberately reused for both the logical and dial addresses.
+func (c ClickHouseConfig) ValidateConnectHost() error {
+	host := c.ConnectHost
+	if host == "" {
+		return nil
+	}
+	if strings.TrimSpace(host) != host {
+		return fmt.Errorf("clickhouse.connect_host must not contain surrounding whitespace")
+	}
+	if net.ParseIP(host) != nil {
+		return nil
+	}
+	if strings.ContainsAny(host, "/\\?#@[]:") {
+		return fmt.Errorf("clickhouse.connect_host %q must contain only a hostname or unbracketed IP address, without a scheme, port, path, userinfo, query, or fragment", host)
+	}
+
+	// Validate DNS hostname syntax without resolving it. A trailing dot is
+	// accepted for fully-qualified domain names, but empty/interior labels and
+	// labels that do not follow RFC 1123 host syntax are rejected.
+	dnsName := strings.TrimSuffix(host, ".")
+	if dnsName == "" || len(dnsName) > 253 {
+		return fmt.Errorf("clickhouse.connect_host %q is not a valid hostname or IP address", host)
+	}
+	for _, label := range strings.Split(dnsName, ".") {
+		if len(label) == 0 || len(label) > 63 || !isHostnameAlphaNum(label[0]) || !isHostnameAlphaNum(label[len(label)-1]) {
+			return fmt.Errorf("clickhouse.connect_host %q is not a valid hostname or IP address", host)
+		}
+		for i := 1; i < len(label)-1; i++ {
+			if !isHostnameAlphaNum(label[i]) && label[i] != '-' {
+				return fmt.Errorf("clickhouse.connect_host %q is not a valid hostname or IP address", host)
+			}
+		}
+	}
+	return nil
+}
+
+func isHostnameAlphaNum(ch byte) bool {
+	return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9'
 }
 
 // Defaults applied by the Effective* getters when the corresponding field is 0.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -186,6 +186,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 		yamlContent := `
 clickhouse:
   host: "test-host"
+  connect_host: "10.0.0.25"
   port: 9000
   database: "test-db"
   username: "test-user"
@@ -212,6 +213,7 @@ logging:
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
 		require.Equal(t, "test-host", cfg.ClickHouse.Host)
+		require.Equal(t, "10.0.0.25", cfg.ClickHouse.ConnectHost)
 		require.Equal(t, 9000, cfg.ClickHouse.Port)
 		require.Equal(t, "test-db", cfg.ClickHouse.Database)
 		require.Equal(t, "test-user", cfg.ClickHouse.Username)
@@ -234,6 +236,7 @@ logging:
 		jsonContent := `{
   "clickhouse": {
     "host": "json-host",
+    "connect_host": "proxy.internal",
     "port": 8123,
     "database": "json-db",
     "username": "json-user",
@@ -264,6 +267,7 @@ logging:
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
 		require.Equal(t, "json-host", cfg.ClickHouse.Host)
+		require.Equal(t, "proxy.internal", cfg.ClickHouse.ConnectHost)
 		require.Equal(t, 8123, cfg.ClickHouse.Port)
 		require.Equal(t, "json-db", cfg.ClickHouse.Database)
 		require.Equal(t, "json-user", cfg.ClickHouse.Username)
@@ -331,6 +335,33 @@ clickhouse:
 		require.Error(t, err)
 		require.Nil(t, cfg)
 	})
+}
+
+func TestClickHouseConfigValidateConnectHost(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"", "proxy.internal", "localhost", "service-name", "service.example.", "10.0.0.25", "2001:db8::10"}
+	for _, host := range valid {
+		host := host
+		t.Run("valid_"+strings.ReplaceAll(host, ":", "_"), func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, (ClickHouseConfig{ConnectHost: host}).ValidateConnectHost())
+		})
+	}
+
+	invalid := []string{
+		" https://10.0.0.25", "https://10.0.0.25", "10.0.0.25:8443",
+		"proxy.internal/path", "proxy.internal?x=1", "proxy.internal#fragment",
+		"user@proxy.internal", "[2001:db8::10]", "[2001:db8::10]:8443",
+		"proxy_internal", "-proxy.internal", "proxy..internal", "proxy.internal ",
+	}
+	for _, host := range invalid {
+		host := host
+		t.Run("invalid_"+strings.NewReplacer(":", "_", "/", "_").Replace(host), func(t *testing.T) {
+			t.Parallel()
+			require.Error(t, (ClickHouseConfig{ConnectHost: host}).ValidateConnectHost())
+		})
+	}
 }
 
 // TestConfigConstants tests configuration constants

--- a/pkg/server/multicluster_router_test.go
+++ b/pkg/server/multicluster_router_test.go
@@ -47,7 +47,7 @@ func TestMulticlusterRouter_AllowlistRejection(t *testing.T) {
 		Enabled:          true,
 		ClusterAllowlist: []string{"otel", "antalya"},
 	}
-	ch := config.ClickHouseConfig{Host: "chi-{cluster}-{cluster}-0-0.demo", Port: 8443}
+	ch := config.ClickHouseConfig{Host: "chi-{cluster}-{cluster}-0-0.demo", ConnectHost: "10.0.0.25", Port: 8443}
 	router, err := NewMulticlusterRouter(mc, ch)
 	require.NoError(t, err)
 
@@ -92,9 +92,9 @@ func TestMulticlusterRouter_HostExpansion(t *testing.T) {
 	t.Parallel()
 	mc := config.MulticlusterConfig{
 		Enabled:          true,
-		ClusterAllowlist: []string{"alpha"},
+		ClusterAllowlist: []string{"alpha", "beta"},
 	}
-	ch := config.ClickHouseConfig{Host: "chi-{cluster}-{cluster}-0-0.demo", Port: 8443}
+	ch := config.ClickHouseConfig{Host: "chi-{cluster}-{cluster}-0-0.demo", ConnectHost: "10.0.0.25", Port: 8443}
 	router, err := NewMulticlusterRouter(mc, ch)
 	require.NoError(t, err)
 
@@ -102,7 +102,14 @@ func TestMulticlusterRouter_HostExpansion(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "chi-alpha-alpha-0-0.demo", cfg.Host)
 	// Other fields preserved.
+	require.Equal(t, "10.0.0.25", cfg.ConnectHost)
 	require.Equal(t, 8443, cfg.Port)
+
+	cfg2, ok := router.ValidateClusterAllowed("beta")
+	require.True(t, ok)
+	require.Equal(t, "chi-beta-beta-0-0.demo", cfg2.Host)
+	require.Equal(t, cfg.ConnectHost, cfg2.ConnectHost)
+	require.Equal(t, cfg.Port, cfg2.Port)
 }
 
 func TestMulticlusterRouter_EmptyAllowlistAllowsAny(t *testing.T) {

--- a/pkg/server/server_client.go
+++ b/pkg/server/server_client.go
@@ -5,7 +5,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -295,7 +297,7 @@ const (
 // probe.
 func (s *ClickHouseJWEServer) newClientWithOAuth(ctx context.Context, chCfg config.ClickHouseConfig, token string) (*clickhouse.Client, error) {
 	cfg := s.Config.Server.OAuth
-	endpoint := fmt.Sprintf("%s:%d", chCfg.Host, chCfg.Port)
+	endpoint := net.JoinHostPort(chCfg.Host, strconv.Itoa(chCfg.Port))
 
 	// Cache hit — use the stored method. chCfg carries any per-request roles,
 	// which newClientForOAuthMethod applies via the CH client.

--- a/pkg/server/server_client.go
+++ b/pkg/server/server_client.go
@@ -5,9 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -297,7 +295,7 @@ const (
 // probe.
 func (s *ClickHouseJWEServer) newClientWithOAuth(ctx context.Context, chCfg config.ClickHouseConfig, token string) (*clickhouse.Client, error) {
 	cfg := s.Config.Server.OAuth
-	endpoint := net.JoinHostPort(chCfg.Host, strconv.Itoa(chCfg.Port))
+	endpoint := fmt.Sprintf("%s:%d", chCfg.Host, chCfg.Port)
 
 	// Cache hit — use the stored method. chCfg carries any per-request roles,
 	// which newClientForOAuthMethod applies via the CH client.


### PR DESCRIPTION
## Summary

- add optional `clickhouse.connect_host` configuration through YAML, JSON, CLI, and `CLICKHOUSE_CONNECT_HOST`
- keep `clickhouse.host` as the logical HTTP and TLS identity while overriding only the underlying TCP destination
- support HTTP and native TCP with and without TLS, IPv4/IPv6 address formatting, and static multicluster dial destinations
- validate malformed dial hosts during startup, reload, and direct client creation
- document the setting in the main README and Helm examples

## Why

Some deployments must bypass DNS or connect through a fixed internal address without changing the logical ClickHouse hostname. Using the IP as `clickhouse.host` breaks HTTP routing, TLS SNI, and certificate hostname verification. This change separates those concerns while preserving existing behavior when the override is unset.

Closes #159.

## Validation

- `go test -short ./...`
- `go test -race ./pkg/config ./pkg/clickhouse ./pkg/server -short`
- `go test ./pkg/clickhouse -run '^TestConnectHostPlainProtocols$' -count=1 -v`
- `git diff --check`

The integration test connects successfully to real embedded ClickHouse listeners over both HTTP and native TCP using an intentionally non-resolvable logical hostname and a reachable `connect_host`.
